### PR TITLE
Add accessibility and privacy pages; fix WCAG 2.1 AA issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Python virtual environment
 venv/
+.venv/
 .env/
 
 # Byte-compiled / optimized / DLL files

--- a/.pa11yci
+++ b/.pa11yci
@@ -1,0 +1,28 @@
+{
+  "defaults": {
+    "standard": "WCAG2AA",
+    "runners": ["htmlcs"],
+    "timeout": 30000,
+    "chromeLaunchConfig": {
+      "args": ["--no-sandbox", "--disable-setuid-sandbox"]
+    },
+    "ignore": [
+      "WCAG2AA.Principle3.Guideline3_2.3_2_2.H32.2",
+      "WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.InputCheckbox.Name",
+      "WCAG2AA.Principle1.Guideline1_3.1_3_1.F68"
+    ]
+  },
+  "urls": [
+    "http://127.0.0.1:8000/",
+    "http://127.0.0.1:8000/accessibility.html",
+    "http://127.0.0.1:8000/privacy.html",
+    "http://127.0.0.1:8000/reach_out.html",
+    "http://127.0.0.1:8000/docs/how-to-connect.html",
+    "http://127.0.0.1:8000/docs/what-now.html",
+    "http://127.0.0.1:8000/docs/recommended-hardware.html",
+    "http://127.0.0.1:8000/docs/recommended-settings.html",
+    "http://127.0.0.1:8000/docs/suggested_channels.html",
+    "http://127.0.0.1:8000/docs/host-a-node.html",
+    "http://127.0.0.1:8000/docs/wismesh-repeater-mini-1w.html"
+  ]
+}

--- a/ACCESSIBILITY-CHECKLIST.md
+++ b/ACCESSIBILITY-CHECKLIST.md
@@ -1,0 +1,112 @@
+# Accessibility checklist (WCAG 2.1 AA)
+
+Living checklist for the Arizona Meshtastic Community site. Update the status as
+things are fixed or verified. See [ACCESSIBILITY.md](ACCESSIBILITY.md) for how to
+run the automated audit.
+
+## Status legend
+
+| Mark | Meaning |
+| --- | --- |
+| ✅ auto | Verified automatically (pa11y / HTML_CodeSniffer, `mkdocs --strict`) |
+| ✅ tree | Verified against the browser accessibility tree (what a screen reader consumes) |
+| ✅ check | Verified by inspecting the source / rendered HTML |
+| 🟡 manual | Needs a human pass with a real screen reader or keyboard. Not yet done. |
+| ⬜ todo | Not started |
+| n/a | No content on the site triggers this criterion |
+
+> **The honest gap:** automated tools and the accessibility-tree check cover
+> roughly 30 to 50% of WCAG. The 🟡 items below can only be confirmed by a person
+> using a real screen reader or keyboard. Everything ✅ has evidence behind it.
+
+## 1. Perceivable
+
+| Criterion | Status | Notes |
+| --- | --- | --- |
+| 1.1.1 Non-text content (alt text) | ✅ tree | Every image has descriptive `alt`; confirmed in the accessibility tree on all sampled pages. |
+| 1.3.1 Info & relationships (semantic structure) | ✅ auto | Headings, lists, landmarks are real semantic HTML (Material theme). |
+| 1.3.2 Meaningful sequence | ✅ check | DOM order matches reading order. |
+| 1.4.1 Use of color | 🟡 manual | Spot-check that no info is conveyed by color alone. The red/blue "highlighted" callouts in screenshots are described in the surrounding text, and they are. |
+| 1.4.3 Contrast (minimum) 4.5:1 | ✅ auto | Was the big failure (121 issues, header at 2.78:1). Fixed via `docs/stylesheets/extra.css`; pa11y now reports 0. |
+| 1.4.4 Resize text to 200% | 🟡 manual | Zoom browser to 200% and confirm no clipping or overlap. Material is responsive; expected to pass. |
+| 1.4.5 Images of text | ✅ check | No images of text used for body content (screenshots are illustrative and described in alt). |
+| 1.4.10 Reflow (320px) | 🟡 manual | Check at 320px width or 400% zoom for horizontal scrolling. Material is responsive. |
+| 1.4.11 Non-text contrast (UI/icons) | 🟡 manual | Confirm icon and button borders meet 3:1 in both themes. |
+| 1.4.12 Text spacing | 🟡 manual | Apply a text-spacing bookmarklet; confirm no loss of content. |
+
+## 2. Operable
+
+| Criterion | Status | Notes |
+| --- | --- | --- |
+| 2.1.1 Keyboard | 🟡 manual | Controls are native and focusable (verified in source). Needs a full Tab walk-through; see the procedure below. |
+| 2.1.2 No keyboard trap | 🟡 manual | Verify focus can leave the search box, theme toggle, and the embedded Discord and IRC iframes. |
+| 2.4.1 Bypass blocks (skip link) | ✅ check | "Skip to content" link present on **every** page (homepage was fixed). |
+| 2.4.2 Page titled | ✅ check | Each page has a unique `<title>`. |
+| 2.4.3 Focus order | 🟡 manual | Tab order should match visual order; confirm by hand. |
+| 2.4.4 Link purpose (in context) | ✅ tree | All link names are meaningful. Renamed the generic "Learn More" link to "Learn how to connect". |
+| 2.4.5 Multiple ways | ✅ check | Site has nav tabs, search, and in-page links. |
+| 2.4.6 Headings & labels | ✅ tree | Headings are descriptive; first heading present on every page. |
+| 2.4.7 Focus visible | 🟡 manual | Confirm a visible focus ring on all interactive elements in both themes. Material ships focus styles; verify the darkened header did not reduce ring contrast. |
+| 2.5.3 Label in name | ✅ check | Visible button text matches accessible name. |
+
+## 3. Understandable
+
+| Criterion | Status | Notes |
+| --- | --- | --- |
+| 3.1.1 Language of page | ✅ check | `<html lang="en">` set (`theme.language: en`). |
+| 3.2.1 On focus (no surprise change) | ✅ check | No context change on focus. |
+| 3.2.2 On input | ✅ check | Theme toggle and search change content as expected; no unexpected navigation. |
+| 3.2.3 Consistent navigation | ✅ check | Same nav on every page (Material). |
+| 3.3.1 / 3.3.2 Error ID & labels (forms) | n/a | Site has no data-entry forms (search and theme are framework controls; see ACCESSIBILITY.md). |
+
+## 4. Robust
+
+| Criterion | Status | Notes |
+| --- | --- | --- |
+| 4.1.2 Name, role, value | ✅ tree | Links, buttons, images, and landmarks all expose a correct role and name in the accessibility tree. Two framework controls are documented exceptions (see ACCESSIBILITY.md). |
+| 4.1.3 Status messages | ⬜ todo | The homepage live node-counts update silently. Consider `aria-live="polite"` so screen readers announce updated counts. Low priority. |
+
+---
+
+## Manual screen-reader test procedure ("make sure voice works")
+
+Automated tools cannot confirm the *experience*. Do this short pass once, ideally
+on both a desktop and a mobile screen reader. No purchase needed. **VoiceOver**
+(built into macOS and iOS) and **NVDA** (free, Windows) are enough.
+
+### VoiceOver (macOS), built in and free
+1. Turn it on with **Cmd + F5** (or System Settings, Accessibility, VoiceOver).
+2. Open the site. Press **VO + A** (VO = Control + Option) to read continuously.
+3. Pull up the **rotor** with **VO + U**, then arrow through *Headings*, *Links*,
+   and *Landmarks*. Check that:
+   - The heading list is logical (one H1, sensible order).
+   - Every link name makes sense on its own (no bare "here" or "more").
+   - Landmarks include banner, navigation, main, and content info.
+4. Press **VO + Cmd + H** to jump heading to heading through a content page.
+5. Test the **skip link**: reload, then press **Tab** once. You should hear
+   "Skip to content". Activate it and confirm focus lands in the main content.
+6. Open the **theme toggle** and **search** with the keyboard; confirm they are
+   announced and operable.
+
+### NVDA (Windows), free download from nvaccess.org
+1. Start NVDA (**Ctrl + Alt + N**).
+2. Read all with **NVDA + Down Arrow** (NVDA key = Insert or Caps Lock).
+3. Open element lists with **NVDA + F7**, then review *Links*, *Headings*, and
+   *Landmarks* (same checks as the rotor above).
+4. Navigate by heading with **H**, by landmark with **D**, by link with **K**.
+5. Confirm the **skip link** (Tab from the top of the page) and that focus is
+   never trapped in the search box or the embedded Discord and IRC iframes (Tab
+   should move past them).
+
+### Keyboard-only pass (no mouse, any OS)
+1. Put the mouse aside. From the top of each page, press **Tab** repeatedly.
+2. Confirm that a **visible focus ring** is always present, that focus order
+   matches the visual layout, that you can reach and activate every link, button,
+   tab, and toggle, and that focus is never trapped. **Esc** should close the
+   image lightbox, and the arrow keys should move between lightbox images.
+
+### Record results here
+
+| Date | Tester | Tool | Pages | Result / issues found |
+| --- | --- | --- | --- | --- |
+| _pending_ | | | | |

--- a/ACCESSIBILITY.md
+++ b/ACCESSIBILITY.md
@@ -1,0 +1,51 @@
+# Accessibility testing
+
+This site targets **WCAG 2.1 Level AA**. Accessibility is checked with
+[`pa11y-ci`](https://github.com/pa11y/pa11y-ci), which runs the HTML_CodeSniffer
+WCAG2AA ruleset against the built site in a local headless Chromium. No account
+or API key is required; pa11y is free and runs entirely on your machine.
+
+## Running the audit locally
+
+```bash
+# 1. Build/serve the site (in one terminal)
+mkdocs serve            # serves at http://127.0.0.1:8000
+
+# 2. Install pa11y-ci once (downloads a headless Chromium ~150 MB)
+npm install -g pa11y-ci
+
+# 3. Run the audit (in another terminal, from the repo root)
+pa11y-ci
+```
+
+`pa11y-ci` reads [`.pa11yci`](.pa11yci) for the page list, the WCAG2AA standard,
+and the documented rule exceptions below. A clean run reports
+`11/11 URLs passed`.
+
+> On a minimal Linux box, headless Chromium needs system libraries. Install them
+> with: `sudo apt-get install -y libatk1.0-0 libatk-bridge2.0-0 libcups2
+> libxkbcommon0 libxcomposite1 libxdamage1 libxfixes3 libxrandr2 libgbm1
+> libpango-1.0-0 libcairo2 libnss3 libnspr4 libdrm2 libxshmfence1 libx11-xcb1
+> libasound2t64`
+
+## Documented rule exceptions (`ignore` in `.pa11yci`)
+
+These three findings are produced by **Material for MkDocs' own UI controls**,
+not by this site's content. They appear on essentially every Material site. Each
+control is keyboard-operable and has an accessible name in practice, so they are
+ignored to keep the audit focused on content-level regressions. Re-evaluate these
+whenever the theme is upgraded.
+
+| Rule | Element | Why it's ignored |
+| --- | --- | --- |
+| `H32.2` (3.2.2), *form has no submit button* | Header **search** form and **theme/color-scheme** form | Both are live controls (search filters as you type; the toggle switches theme on change). Neither needs nor has a submit button by design. They have accessible names and work via keyboard. |
+| `H91.InputCheckbox.Name` (4.1.2) | Homepage table-of-contents drawer toggle (`#__toc`) | Material's icon-only TOC toggle. It is associated with a `<label for>` and is announced by screen readers via that association; HTML_CodeSniffer does not credit icon-only labels. |
+| `F68` (1.3.1) | Same `#__toc` toggle | Same root cause as above. The icon-only label is not detected as a text label by the checker. |
+
+## What is actively enforced
+
+Everything else, most importantly **color contrast (WCAG 1.4.3)**. The custom
+overrides in [`docs/stylesheets/extra.css`](docs/stylesheets/extra.css) darken
+the deep-orange header and link colors specifically to keep white-on-orange and
+link text above the 4.5:1 AA threshold. If those overrides are removed, the audit
+fails, by design.

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -1,0 +1,71 @@
+---
+title: Accessibility
+hide:
+  - navigation
+---
+
+# Website Accessibility
+
+We want this website to work for everyone in our community, including people with
+disabilities.
+
+If you use assistive technology such as a screen reader or a Braille display, and
+something on this site gets in the way of finding what you need, please
+[contact us](#contact-us). It helps if you tell us what went wrong, the format
+you would like the information in, the address (URL) of the page, and how to reach
+you. We will get back to you.
+
+## How we approach accessibility
+
+- We aim to meet **Section 508** and the **Web Content Accessibility Guidelines
+  (WCAG) 2.1, Levels A and AA**. These are the common standards for website
+  accessibility. WCAG 2.1 builds on and replaces WCAG 2.0.
+- The site is built to work with the keyboard alone, to provide text
+  descriptions for images, to keep enough color contrast to be readable, and to
+  offer a "skip to content" link for people using a keyboard or screen reader.
+- You can switch between a light and a dark theme using the toggle at the top of
+  the page.
+- If any part of the site is hard to use, or you just have feedback, please
+  [contact us](#contact-us).
+
+## Browser accessibility tools
+
+Most browsers have built-in tools for adjusting text size, zoom, contrast, and
+more:
+
+- [Chrome](https://support.google.com/chrome/answer/7040464)
+- [Firefox](https://support.mozilla.org/en-US/kb/accessibility-features-firefox-make-firefox-easier-to-use)
+- [Microsoft Edge](https://support.microsoft.com/en-us/microsoft-edge/accessibility-features-in-microsoft-edge-4c696192-338e-9465-b2cd-bd9b698ad19a)
+- [Safari](https://support.apple.com/guide/safari/welcome/mac)
+
+## Known limitations
+
+We test the site against WCAG 2.1 AA and fix problems as we find them. A couple of
+things are worth calling out:
+
+- **Embedded chat widgets.** The Reach Out page embeds a live Discord widget and
+  an IRC web chat. Those are run by Discord and Libera.Chat, so we cannot control
+  how accessible they are. If either one is hard to use, you can email us at
+  [contact@azmsh.net](mailto:contact@azmsh.net), or join Discord or IRC directly
+  with a client that works for you.
+- **Volunteer-run.** This site is maintained by volunteers in their spare time.
+  If you hit a barrier we have not listed here, please [tell us](#contact-us) and
+  we will work on it.
+
+## Accommodations
+
+We are a volunteer group, and we want everyone to be able to get to our
+information.
+
+If you need something in a different format, want to report an accessibility
+problem, or need another reasonable accommodation, contact us using the
+information below and we will do our best to help.
+
+## Contact us
+
+- **Email:** [contact@azmsh.net](mailto:contact@azmsh.net)
+- **Discord:** [Join the Arizona Meshtastic Community Discord](https://discord.gg/HrKtyuFEQk)
+
+When you report a problem, it helps to include the address (URL) of the page, the
+browser and assistive technology you are using, and a short note about what
+happened.

--- a/docs/assets/js/a11y.js
+++ b/docs/assets/js/a11y.js
@@ -1,0 +1,26 @@
+// Accessibility: make the "Skip to content" link reliably move keyboard focus
+// into the main content, not just scroll there. Heading targets are not
+// focusable by default, so without this, activating the link leaves focus on
+// <body> and (on short pages) appears to do nothing. Activating a link with the
+// mouse or with Enter both fire a "click" event, so this covers both.
+(function () {
+  function focusSkipTarget(link) {
+    var href = link.getAttribute("href") || "";
+    var id = href.split("#")[1];
+    if (!id) return;
+    var target = document.getElementById(id);
+    if (!target) return;
+    if (!target.hasAttribute("tabindex")) {
+      target.setAttribute("tabindex", "-1");
+    }
+    // Let the browser apply the hash/scroll first, then place focus.
+    setTimeout(function () {
+      target.focus();
+    }, 0);
+  }
+
+  document.addEventListener("click", function (event) {
+    var link = event.target.closest ? event.target.closest("a.md-skip") : null;
+    if (link) focusSkipTarget(link);
+  });
+})();

--- a/docs/docs/host-a-node.md
+++ b/docs/docs/host-a-node.md
@@ -4,30 +4,30 @@ hide:
 title: Host a Node
 ---
 
-# :material-home-assistant: Property Owner FAQ — Hosting a Node
+# :material-home-assistant: Property Owner FAQ. Hosting a Node
 
-Thinking about letting us put a Meshtastic node on your property? Awesome! Here's everything you need to know, in plain English — no tech jargon required.
+Thinking about letting us put a Meshtastic node on your property? Awesome! Here's everything you need to know, in plain English. No tech jargon required.
 
 !!! info "What is Arizona Meshtastic Community?"
-    We're a volunteer-run group building a **free, open-source mesh network** across the Phoenix metro and greater Arizona. Our network lets people send text messages without cell service, Wi-Fi, or monthly fees — using small, low-power radios. Learn more at [azmsh.net](https://azmsh.net).
+    We're a volunteer-run group building a **free, open-source mesh network** across the Phoenix metro and greater Arizona. Our network lets people send text messages without cell service, Wi-Fi, or monthly fees. Using small, low-power radios. Learn more at [azmsh.net](https://azmsh.net).
 
 ---
 
 ## :material-frequently-asked-questions: Frequently Asked Questions
 
 ??? question "What is Meshtastic and what does the node actually do?"
-    Meshtastic is a free, open-source project that turns small radios into a **city-wide text messaging network**. Each node acts as a relay — it receives messages from nearby devices and passes them along to the next node, extending the network's reach.
+    Meshtastic is a free, open-source project that turns small radios into a **city-wide text messaging network**. Each node acts as a relay. It receives messages from nearby devices and passes them along to the next node, extending the network's reach.
 
     Think of it like a chain of walkie-talkies that automatically forward messages. The more nodes we have, the farther messages can travel.
 
     **Why does this matter?**
 
-    - **Emergency preparedness** — when cell towers go down (monsoons, wildfires, grid failures), Meshtastic keeps working
-    - **Outdoor recreation** — hikers, off-roaders, and trail runners can communicate in areas with zero cell coverage
-    - **Community resilience** — a communication network that nobody owns and everybody benefits from
+    - **Emergency preparedness**. When cell towers go down (monsoons, wildfires, grid failures), Meshtastic keeps working
+    - **Outdoor recreation**. Hikers, off-roaders, and trail runners can communicate in areas with zero cell coverage
+    - **Community resilience**. A communication network that nobody owns and everybody benefits from
 
 ??? question "What does the equipment look like?"
-    A typical node is a **small weatherproof box** — roughly the size of a deck of cards or a small paperback book. It weighs under 2 pounds. Most setups include:
+    A typical node is a **small weatherproof box**, roughly the size of a deck of cards or a small paperback book. It weighs under 2 pounds. Most setups include:
 
     - The node itself (a small microcontroller in a weatherproof case)
     - A small antenna (usually 6-12 inches tall)
@@ -36,10 +36,10 @@ Thinking about letting us put a Meshtastic node on your property? Awesome! Here'
     From the street, it looks similar to a security camera, weather station, or small satellite antenna. Most people walk right past them without noticing.
 
     !!! tip "Mounting is non-invasive"
-        We use **magnetic mounts, pole clamps, or zip ties** — no drilling into your roof, walls, or structure unless you specifically approve it. The equipment can be removed without leaving any trace.
+        We use **magnetic mounts, pole clamps, or zip ties**. No drilling into your roof, walls, or structure unless you specifically approve it. The equipment can be removed without leaving any trace.
 
 ??? question "Does it use my internet or Wi-Fi?"
-    **No.** The node communicates entirely over radio frequencies (the 906.875 MHz unlicensed band) — it does not connect to your Wi-Fi, use your internet bandwidth, or access any of your home network.
+    **No.** The node communicates entirely over radio frequencies (the 906.875 MHz unlicensed band). It does not connect to your Wi-Fi, use your internet bandwidth, or access any of your home network.
 
     There is an optional feature called MQTT that *can* connect to the internet for extended range, but that is never enabled without your knowledge and permission. The default setup is fully radio-only and self-contained.
 
@@ -50,19 +50,19 @@ Thinking about letting us put a Meshtastic node on your property? Awesome! Here'
     |--------|---------------|
     | Cell phone | Up to 2,000 mW |
     | Wi-Fi router | Up to 1,000 mW |
-    | **Meshtastic node** | **100–4,500 mW** |
+    | **Meshtastic node** | **100-4,500 mW** |
     | Baby monitor | Up to 100 mW |
 
-    Even at maximum power, the node transmits only in **short bursts** (a few seconds at a time), not continuously. It operates in the **902–928 MHz unlicensed band**, which is the same frequency range used by garage door openers and weather stations. All equipment is **FCC-compliant** and legal to operate without a license.
+    Even at maximum power, the node transmits only in **short bursts** (a few seconds at a time), not continuously. It operates in the **902-928 MHz unlicensed band**, which is the same frequency range used by garage door openers and weather stations. All equipment is **FCC-compliant** and legal to operate without a license.
 
     The antenna is mounted outdoors, away from living spaces, so actual exposure is far less than holding a phone to your ear.
 
 ??? question "Will it damage my roof or property?"
     **No.** We design every installation to be completely non-invasive:
 
-    - **Magnetic mounts** — stick to metal surfaces, lift right off
-    - **Pole clamps / J-mounts** — attach to existing masts, railings, or fascia boards with clamps
-    - **Zip ties / Velcro** — for lightweight setups on pipes or pergolas
+    - **Magnetic mounts**. Stick to metal surfaces, lift right off
+    - **Pole clamps / J-mounts**. Attach to existing masts, railings, or fascia boards with clamps
+    - **Zip ties / Velcro**. For lightweight setups on pipes or pergolas
 
     We never drill, screw, or permanently modify your property unless you explicitly ask us to. If the node is removed, there is no visible evidence it was ever there.
 
@@ -70,17 +70,17 @@ Thinking about letting us put a Meshtastic node on your property? Awesome! Here'
         Arizona's extreme environment is harsh on outdoor equipment. We use **UV-resistant enclosures**, **heat-rated cables**, and **weatherproof connectors** designed to handle 115F+ summers, intense UV exposure, and monsoon-driven wind and rain. Our experienced installers know how to mount equipment that survives Arizona weather year after year.
 
 ??? question "Do I have to pay for anything?"
-    **No.** The Arizona Meshtastic Community provides the equipment, installs it, and maintains it — all at no cost to you. The only thing the node uses is a tiny amount of electricity if it's plugged into a USB outlet instead of running on solar.
+    **No.** The Arizona Meshtastic Community provides the equipment, installs it, and maintains it. All at no cost to you. The only thing the node uses is a tiny amount of electricity if it's plugged into a USB outlet instead of running on solar.
 
-    **How tiny?** A Meshtastic node draws about **1–2 watts** — roughly the same as a phone charger with nothing plugged in. That's about **$1–2 per year** on your electric bill. Most of our nodes run on solar and cost you nothing at all.
+    **How tiny?** A Meshtastic node draws about **1-2 watts**, roughly the same as a phone charger with nothing plugged in. That's about **$1-2 per year** on your electric bill. Most of our nodes run on solar and cost you nothing at all.
 
 ??? question "What about my HOA?"
-    Great question — we know HOAs are a big deal in the Phoenix metro. Here's why a Meshtastic node typically flies under the radar:
+    Great question. We know HOAs are a big deal in the Phoenix metro. Here's why a Meshtastic node typically flies under the radar:
 
-    - **Size** — smaller than most security cameras or weather stations
-    - **Appearance** — clean, unobtrusive, and professionally mounted
-    - **FCC protection** — federal law ([OTARD rule](https://www.fcc.gov/media/over-air-reception-devices-rule)) limits HOA restrictions on small antennas, especially those under 1 meter (39 inches)
-    - **Precedent** — if your HOA allows Ring cameras, weather stations, or satellite dishes, a Meshtastic node is in the same category
+    - **Size**. Smaller than most security cameras or weather stations
+    - **Appearance**. Clean, unobtrusive, and professionally mounted
+    - **FCC protection**. Federal law ([OTARD rule](https://www.fcc.gov/media/over-air-reception-devices-rule)) limits HOA restrictions on small antennas, especially those under 1 meter (39 inches)
+    - **Precedent**. If your HOA allows Ring cameras, weather stations, or satellite dishes, a Meshtastic node is in the same category
 
     !!! tip "We can help with HOA conversations"
         If your HOA has questions, we're happy to provide documentation, spec sheets, or even attend a board meeting to explain the setup. We've navigated Arizona HOAs before and can help you find an installation approach that keeps everyone happy.
@@ -88,22 +88,22 @@ Thinking about letting us put a Meshtastic node on your property? Awesome! Here'
     That said, we always recommend checking your CC&Rs first. If your HOA has strict antenna rules, we can often find a discreet mounting location (inside an attic, on a back-facing eave, etc.) that avoids any issues.
 
 ??? question "What if I want it removed?"
-    **No problem at all.** There is no long-term obligation. If you want the node removed for any reason — selling the house, changing your mind, remodeling — just let us know and we'll come pick it up.
+    **No problem at all.** There is no long-term obligation. If you want the node removed for any reason (selling the house, changing your mind, remodeling), just let us know and we'll come pick it up.
 
-    - Removal takes about 15–30 minutes
+    - Removal takes about 15-30 minutes
     - No damage, no holes, no residue
     - The community handles everything
 
 ??? question "How far does the signal reach?"
-    In Arizona's flat, open terrain, a well-placed rooftop node can reach **5–30+ miles** depending on elevation and antenna height. Even in suburban neighborhoods, 2–10 miles is typical.
+    In Arizona's flat, open terrain, a well-placed rooftop node can reach **5-30+ miles** depending on elevation and antenna height. Even in suburban neighborhoods, 2-10 miles is typical.
 
-    The magic of a mesh network is that each node extends the range. Your node doesn't need to reach the whole city — it just needs to reach the *next* node, and the message hops along from there.
+    The magic of a mesh network is that each node extends the range. Your node doesn't need to reach the whole city. It just needs to reach the *next* node, and the message hops along from there.
 
 ??? question "Will it interfere with my Wi-Fi, TV, or garage door?"
     **No.** Meshtastic operates on **906.875 MHz**, which is a completely different frequency from:
 
     - Wi-Fi (2.4 GHz / 5 GHz / 6 GHz)
-    - Cell phones (700 MHz–2.5 GHz, different bands)
+    - Cell phones (700 MHz-2.5 GHz, different bands)
     - TV (VHF/UHF, different bands)
     - Bluetooth (2.4 GHz)
 
@@ -114,14 +114,14 @@ Thinking about letting us put a Meshtastic node on your property? Awesome! Here'
 
     - **Solar-powered nodes** are electrically isolated from your home's wiring, so a strike to the node won't travel into your house
     - **Proper grounding** is part of every installation where a mast or pole is used
-    - A small antenna does **not meaningfully increase** the probability of a lightning strike — it's far shorter than your roof peak, chimney, or any nearby trees
+    - A small antenna does **not meaningfully increase** the probability of a lightning strike. It's far shorter than your roof peak, chimney, or any nearby trees
 
     Our equipment is weatherproof and rated for heavy rain, dust storms, and high winds. We've been through multiple monsoon seasons with our installations.
 
 ??? question "How do I sign up to host a node?"
     We'd love to hear from you! The best way to get started:
 
-    1. **Join our Discord** — [discord.gg/HrKtyuFEQk](https://discord.gg/HrKtyuFEQk)
+    1. **Join our Discord**. [Discord.gg/HrKtyuFEQk](https://discord.gg/HrKtyuFEQk)
     2. Introduce yourself in the **#general** channel and mention you're interested in hosting
     3. A volunteer will reach out to discuss your location, line-of-sight, and the best mounting options
 
@@ -131,7 +131,7 @@ Thinking about letting us put a Meshtastic node on your property? Awesome! Here'
 
 ## :material-map-marker-radius: Why Node Placement Matters in Arizona
 
-Arizona's geography gives us a huge advantage for mesh networking — wide-open desert, minimal tree cover, and lots of flat rooftops with clear line-of-sight. But it also means **elevation is everything**. A node on a single-story roof in a subdivision can reach dramatically farther than the same node at ground level.
+Arizona's geography gives us a huge advantage for mesh networking. Wide-open desert, minimal tree cover, and lots of flat rooftops with clear line-of-sight. But it also means **elevation is everything**. A node on a single-story roof in a subdivision can reach dramatically farther than the same node at ground level.
 
 The best host locations are:
 

--- a/docs/docs/how-to-connect.md
+++ b/docs/docs/how-to-connect.md
@@ -9,7 +9,7 @@ title: How to Connect
 Welcome to the Arizona Meshtastic Community! This guide will walk you through getting your first device set up and connected to our local mesh network.
 
 !!! info "Before you start"
-    **You will need a Meshtastic radio.** If you don't have one yet, check our [Recommended Hardware](/docs/recommended-hardware.html) page — you can get started for as little as $30. No monthly fees, no subscriptions, no cell service required. Meshtastic runs on unlicensed 915 MHz radio frequencies, so it is completely free and legal to use in the United States.
+    **You will need a Meshtastic radio.** If you don't have one yet, check our [Recommended Hardware](/docs/recommended-hardware.html) page. You can get started for as little as $30. No monthly fees, no subscriptions, no cell service required. Meshtastic runs on unlicensed 915 MHz radio frequencies, so it is completely free and legal to use in the United States.
 
 ---
 
@@ -22,10 +22,10 @@ Before anything else, make sure your device is running the latest Meshtastic fir
 3. Click **Flash** and follow the on-screen instructions.
 
 !!! tip "DFU Mode"
-    Some devices need to be put into DFU (Device Firmware Update) mode before flashing. Check your device's documentation for how to enter DFU mode -- it usually involves holding a button while powering on.
+    Some devices need to be put into DFU (Device Firmware Update) mode before flashing. Check your device's documentation for how to enter DFU mode. It usually involves holding a button while powering on.
 
 !!! warning "Back Up Your Settings First"
-    Firmware updates can wipe your device settings, including your **private key**. Before updating, go to your Meshtastic app and export/back up your configuration. Your private key is what identifies your node on the network -- if you lose it, you will appear as a new node.
+    Firmware updates can wipe your device settings, including your **private key**. Before updating, go to your Meshtastic app and export/back up your configuration. Your private key is what identifies your node on the network. If you lose it, you will appear as a new node.
 
 ---
 
@@ -45,10 +45,10 @@ Install the official Meshtastic app on your phone:
 1. Turn on your Meshtastic device.
 2. Open the Meshtastic app on your phone.
 3. Tap the **+** button to add a new device.
-4. Your device should appear in the list -- tap it to pair.
+4. Your device should appear in the list. Tap it to pair.
 5. If prompted for a pairing code, the default is usually printed on your device or in its documentation.
 
-That is it -- you should now see your node in the app!
+That is it. You should now see your node in the app!
 
 ---
 
@@ -68,7 +68,7 @@ Once your settings are configured:
 
 1. Open the Meshtastic app.
 2. Go to the **Messages** tab.
-3. Send a message on the primary channel -- say hello!
+3. Send a message on the primary channel. Say hello!
 
 !!! info "Be Patient"
     Meshtastic is a long-range, low-bandwidth radio network. Messages can take a few seconds (or longer) to propagate across the mesh. This is normal.
@@ -77,12 +77,12 @@ Once your settings are configured:
 
 ## Quick Tips
 
-- **Keep your firmware updated** -- new versions improve performance and compatibility.
+- **Keep your firmware updated**. New versions improve performance and compatibility.
 - **Export your node configuration** before any firmware update so you do not lose your identity on the mesh.
-- **Start with the Client Mute role** if you are not sure what to pick -- it is the safest default for mobile devices.
+- **Start with the Client Mute role** if you are not sure what to pick. It is the safest default for mobile devices.
 - **Check the [Recommended Settings](/docs/recommended-settings.html) page** for detailed configuration guidance (broadcast intervals, MQTT, and more).
-- **Upgrade your antenna** -- the single biggest improvement you can make. See the [Recommended Hardware](/docs/recommended-hardware.html) page for our antenna picks.
-- **Ask questions in Discord** -- the community is friendly and happy to help new members get started.
+- **Upgrade your antenna**. The single biggest improvement you can make. See the [Recommended Hardware](/docs/recommended-hardware.html) page for our antenna picks.
+- **Ask questions in Discord**. The community is friendly and happy to help new members get started.
 
 !!! tip "How far does Meshtastic reach?"
     Range depends on terrain and antenna height. In flat desert terrain, handheld-to-handheld range is typically 1-3 miles. With a rooftop node and a good antenna, you can reach 10-30+ miles. The mesh network extends range further by relaying messages through other nodes.

--- a/docs/docs/recommended-hardware.md
+++ b/docs/docs/recommended-hardware.md
@@ -6,11 +6,11 @@ title: Recommended Hardware
 
 # :material-radio-handheld: Recommended Hardware
 
-New to Meshtastic? Here's what to buy. No monthly fees, no subscriptions -- just a one-time purchase and you're on the mesh.
+New to Meshtastic? Here's what to buy. No monthly fees, no subscriptions. Just a one-time purchase and you're on the mesh.
 
 !!! tip "Two things you need"
-    **1. A handheld radio** — carry it with you, pairs with your phone via Bluetooth<br>
-    **2. A rooftop/attic node** — put it up high at your home to keep you connected
+    **1. A handheld radio**. Carry it with you, pairs with your phone via Bluetooth<br>
+    **2. A rooftop/attic node**. Put it up high at your home to keep you connected
 
     That's it. Buy these two things, follow our [How to Connect](/docs/how-to-connect.html) guide, and you're on the mesh.
 
@@ -24,9 +24,9 @@ New to Meshtastic? Here's what to buy. No monthly fees, no subscriptions -- just
 
     ---
 
-    The best all-around handheld for Arizona. GPS, huge 3200 mAh battery (3+ days), IP66 waterproof, solar charging connector. Pairs with your phone over Bluetooth — open the Meshtastic app and start messaging.
+    The best all-around handheld for Arizona. GPS, huge 3200 mAh battery (3+ days), IP66 waterproof, solar charging connector. Pairs with your phone over Bluetooth. Open the Meshtastic app and start messaging.
 
-    **~$89-99** — upgrade the weak stock antenna to the Muziworks 17cm whip (see Antenna Guide below); it's the single biggest improvement you can make.
+    **~$89-99**. Upgrade the weak stock antenna to the Muziworks 17cm whip (see Antenna Guide below); it's the single biggest improvement you can make.
 
     [:material-cart: RAK Store (~$89)](https://store.rakwireless.com/products/wismesh-pocket) · [Rokland (~$99)](https://store.rokland.com/products/wismesh-pocket)
 
@@ -34,16 +34,16 @@ New to Meshtastic? Here's what to buy. No monthly fees, no subscriptions -- just
 
     ---
 
-    A community build that drops the RAK 1W Booster Kit into the WisMesh Repeater Mini's solar enclosure: **1W (30 dBm) of TX power** — about 6x a typical node — solar self-sustaining, **no soldering**. Designed and field-tested by **prayingmedic**.
+    A community build that drops the RAK 1W Booster Kit into the WisMesh Repeater Mini's solar enclosure: **1W (30 dBm) of TX power** (about 6x a typical node), solar self-sustaining, **no soldering**. Designed and field-tested by **prayingmedic**.
 
-    **~$125-150 in parts** — every step is documented for first-time builders.
+    **~$125-150 in parts**. Every step is documented for first-time builders.
 
     [:material-tools: Full Build Guide](/docs/wismesh-repeater-mini-1w.html){ .md-button .md-button--primary }
 
 </div>
 
-!!! warning "Rooftop runner-up: Station G2 (~$100-130) — currently sold out"
-    The most powerful consumer Meshtastic radio (up to **36.5 dBm / 4.5W**) and our long-time rooftop pick — but it's **sold out and extremely hard to get right now**. Check [B&Q Consulting](https://shop.uniteng.com/product/meshtastic-mesh-device-station-edition/) for restocks; until then, the Repeater Mini 1W build above is the one to get.
+!!! warning "Rooftop runner-up: Station G2 (~$100-130). Currently sold out"
+    The most powerful consumer Meshtastic radio (up to **36.5 dBm / 4.5W**) and our long-time rooftop pick. But it's **sold out and extremely hard to get right now**. Check [B&Q Consulting](https://shop.uniteng.com/product/meshtastic-mesh-device-station-edition/) for restocks; until then, the Repeater Mini 1W build above is the one to get.
 
 !!! warning "Why you need a rooftop node"
     **This is the #1 mistake new users make.** A handheld alone will struggle indoors and at range. Put a node up high and the difference is night and day.
@@ -67,34 +67,34 @@ These radios pair with your phone over Bluetooth so you can type messages on you
 | **LILYGO T-Deck Plus** | 2000 mAh | ~1-2 days | 2.8" Color LCD | ~$77-87 | Full keyboard, standalone (ESP32) |
 
 !!! info "Battery life varies"
-    These estimates assume typical use — mostly listening with occasional messages. Heavy messaging, constant screen-on, or active GPS tracking will reduce battery life. Power-saving mode can extend it significantly.
+    These estimates assume typical use. Mostly listening with occasional messages. Heavy messaging, constant screen-on, or active GPS tracking will reduce battery life. Power-saving mode can extend it significantly.
 
-!!! success "Upgrade your antenna — the single best $12 you can spend"
-    **Most handheld Meshtastic radios ship with terrible stock antennas.** The stubby antennas that come in the box are only ~69% efficient — nearly a third of your signal is wasted as heat instead of reaching the mesh.
+!!! success "Upgrade your antenna. The single best $12 you can spend"
+    **Most handheld Meshtastic radios ship with terrible stock antennas.** The stubby antennas that come in the box are only ~69% efficient. Nearly a third of your signal is wasted as heat instead of reaching the mesh.
 
     **Our recommendation: [Muziworks 17cm Whip Antenna](https://muzi.works/products/whip-antenna-17cm) (~$12)**
 
-    - **SMA Male connector** — fits most handhelds directly
+    - **SMA Male connector**. Fits most handhelds directly
     - Community reports significantly better range compared to stock antennas (manufacturer-rated SWR of 1.3)
     - 17cm flexible whip, 915 MHz tuned
     - Available individually (~$12) or in a [4-pack (~$36)](https://muzi.works/products/4-pack-whip-antenna-17cm-915mhz)
     - Also available on [Amazon](https://www.amazon.com/muzi-%E1%B4%A1%E1%B4%8F%CA%80%E1%B4%8B%EA%9C%B1-915Mhz-Antenna-Meshtastic/dp/B0D7D6866W)
 
     **Works with:** RAK WisMesh Pocket (SMA), LILYGO T-Echo (SMA), Heltec V3/V4 (needs U.FL to SMA pigtail), LILYGO T-Beam (SMA), LILYGO T-Deck Plus (SMA)<br>
-    **Does NOT apply to:** Card-style trackers (WisMesh Tag, SenseCAP T-1000e) — these have sealed internal antennas with no external port.<br>
-    **Nano G2 Ultra note:** The Nano G2 Ultra has a custom wideband internal antenna engineered for body-proximity use — it doesn't have an external port and doesn't need an upgrade.
+    **Does NOT apply to:** Card-style trackers (WisMesh Tag, SenseCAP T-1000e). These have sealed internal antennas with no external port.<br>
+    **Nano G2 Ultra note:** The Nano G2 Ultra has a custom wideband internal antenna engineered for body-proximity use. It doesn't have an external port and doesn't need an upgrade.
 
 ---
 
 #### :material-star-outline: Budget Pick: Seeed Wio Tracker L1 (~$30)
 
-The best value in Meshtastic right now. For around $30 you get a radio, GPS, screen, and battery — ready to go.
+The best value in Meshtastic right now. For around $30 you get a radio, GPS, screen, and battery. Ready to go.
 
 - **Battery:** 800 mAh (~2-3 days typical)
 - **Screen:** 0.96" OLED
 - **GPS:** Built-in
 
-The **L1 Pro** (~$43) is worth the extra $13 — bigger 1.3" OLED screen, joystick navigation, solar charging, 2000 mAh battery, and an RP-SMA antenna connector for upgrades.
+The **L1 Pro** (~$43) is worth the extra $13. Bigger 1.3" OLED screen, joystick navigation, solar charging, 2000 mAh battery, and an RP-SMA antenna connector for upgrades.
 
 :material-cart: [Seeed Studio L1 ($29.90)](https://www.seeedstudio.com/Wio-Tracker-L1-p-6453.html) | [L1 Pro ($42.90)](https://www.seeedstudio.com/Wio-Tracker-L1-Pro-p-6454.html) | [Amazon (L1 Pro)](https://www.amazon.com/seeed-studio-L1-Pro-Tracker/dp/B0FNCS5ST1)
 
@@ -102,14 +102,14 @@ The **L1 Pro** (~$43) is worth the extra $13 — bigger 1.3" OLED screen, joysti
 
 #### :material-battery-high: Battery Champion: Heltec T114 (~$25-45)
 
-The best budget-to-mid-range option if battery life is your priority. The T114 supports a standard 18650 battery, giving it up to a week of runtime without charging — significantly outperforming the T-Echo on battery life at a lower price. Color TFT display, solar input, and ultra-low sleep current round out an impressive feature set.
+The best budget-to-mid-range option if battery life is your priority. The T114 supports a standard 18650 battery, giving it up to a week of runtime without charging. Significantly outperforming the T-Echo on battery life at a lower price. Color TFT display, solar input, and ultra-low sleep current round out an impressive feature set.
 
 - **Battery:** 800 mAh built-in or 18650 cell (up to ~3000 mAh, up to a week runtime)
 - **Screen:** 1.14" Color TFT
 - **GPS:** Built-in
 - **Extras:** Solar charging input, ultra-low sleep current
 
-Available in several variants — the base model starts around $25, and versions with 18650 battery holder run ~$35-45.
+Available in several variants. The base model starts around $25, and versions with 18650 battery holder run ~$35-45.
 
 :material-cart: [Heltec Store](https://heltec.org/project/mesh-node-t114/)
 
@@ -128,13 +128,13 @@ A proven community favorite. The e-ink display (like a Kindle) is perfectly read
 
 :material-cart: [LILYGO Store (~$60)](https://lilygo.cc/products/t-echo-meshtastic) | [Rokland (~$68)](https://store.rokland.com/products/lilygo-ttgo-meshtastic-t-echo-white-lora-sx1262-wireless-module-915mhz-nrf52840-gps-for-arduino)
 
-**Alternative: Elecrow ThinkNode M1 (~$40-58)** — A T-Echo alternative with a bigger 1200 mAh battery and E-Ink display at a lower price point. Worth considering if you like the T-Echo form factor but want more battery for less money.
+**Alternative: Elecrow ThinkNode M1 (~$40-58)**, a T-Echo alternative with a bigger 1200 mAh battery and E-Ink display at a lower price point. Worth considering if you like the T-Echo form factor but want more battery for less money.
 
 ---
 
 #### :material-trophy: Best Overall: RAK WisMesh Pocket V2 (~$89-99)
 
-The gold standard grab-and-go handheld. Comes ready to use out of the box — no flashing, no tinkering. Big battery, IP66 waterproof, solar connector, and modular expansion slots.
+The gold standard grab-and-go handheld. Comes ready to use out of the box, no flashing, no tinkering. Big battery, IP66 waterproof, solar connector, and modular expansion slots.
 
 - **Battery:** 3200 mAh (~3+ days with GPS and screen active)
 - **Screen:** 1.3" OLED with button navigation
@@ -147,7 +147,7 @@ The gold standard grab-and-go handheld. Comes ready to use out of the box — no
 
 #### :material-signal-variant: Best Antenna: B&Q Nano G2 Ultra (~$85-90)
 
-If you care about the best possible signal from a handheld, this is it. The Nano G2 Ultra has a custom wideband antenna (815-940 MHz) engineered specifically for body-proximity use — most antennas lose performance near your body, this one doesn't. No screen — use it with your phone app.
+If you care about the best possible signal from a handheld, this is it. The Nano G2 Ultra has a custom wideband antenna (815-940 MHz) engineered specifically for body-proximity use. Most antennas lose performance near your body, this one doesn't. No screen. Use it with your phone app.
 
 - **Battery Life:** ~5 days typical
 - **GPS:** Built-in
@@ -172,7 +172,7 @@ Want to leave your phone in your pocket? The T-Deck Plus has a full physical key
 
 #### :material-map-marker: Card-Style Trackers
 
-Credit-card-sized GPS trackers with no screen or buttons — toss one in a backpack, clip it to a pet collar, or leave it in a vehicle. They report location to the mesh automatically.
+Credit-card-sized GPS trackers with no screen or buttons. Toss one in a backpack, clip it to a pet collar, or leave it in a vehicle. They report location to the mesh automatically.
 
 **Our pick: RAK WisMesh Tag (~$39)**
 
@@ -185,7 +185,7 @@ Credit-card-sized GPS trackers with no screen or buttons — toss one in a backp
 
 **Alternative: SenseCAP T-1000e (~$39)**
 
-Similar card form factor but **smaller battery (700 mAh)** and **much lower TX power (13.9 dBm vs 22 dBm)**. The WisMesh Tag is the better choice — nearly double the battery life and significantly more transmit power for the same price.
+Similar card form factor but **smaller battery (700 mAh)** and **much lower TX power (13.9 dBm vs 22 dBm)**. The WisMesh Tag is the better choice, nearly double the battery life and significantly more transmit power for the same price.
 
 !!! warning "Make sure you buy the T-1000**e**"
     The "e" is the Meshtastic-compatible version. Other T-1000 models won't work with Meshtastic.
@@ -208,11 +208,11 @@ These are permanent nodes mounted high on your roof, attic, or mast. They're the
 
 #### :material-trophy: Best Overall: WisMesh Repeater Mini 1W (~$125-150)
 
-Our #1 rooftop node — a community build that puts the RAK 1W Booster Kit (RAK3401) inside the WisMesh Repeater Mini's solar enclosure. The 1W board fits the enclosure's standard mounting-plate holes with no modification and **no soldering**, giving you **30 dBm (1W) of TX power** — roughly 6x a typical 22 dBm node, with better receive too thanks to the RAK13302's RF/SAW filter. The low-power nRF52840 plus the Mini's solar panel keep it topped up; prayingmedic's field test held battery voltage in a narrow 3.80-3.84 V band across 5 days mounted vertically on a 10 ft mast.
+Our #1 rooftop node. A community build that puts the RAK 1W Booster Kit (RAK3401) inside the WisMesh Repeater Mini's solar enclosure. The 1W board fits the enclosure's standard mounting-plate holes with no modification and **no soldering**, giving you **30 dBm (1W) of TX power**, roughly 6x a typical 22 dBm node, with better receive too thanks to the RAK13302's RF/SAW filter. The low-power nRF52840 plus the Mini's solar panel keep it topped up; prayingmedic's field test held battery voltage in a narrow 3.80-3.84 V band across 5 days mounted vertically on a 10 ft mast.
 
 - **Chip:** nRF52840 + RAK13302 1W LoRa module (with PA + RF/SAW filter)
 - **TX Power:** 30 dBm (1W)
-- **Power:** Solar (panel built into the donor enclosure) + Li-ion battery — no AC needed
+- **Power:** Solar (panel built into the donor enclosure) + Li-ion battery. No AC needed
 - **WiFi:** No (Bluetooth only)
 - **Soldering:** None
 
@@ -222,18 +222,18 @@ Our #1 rooftop node — a community build that puts the RAK 1W Booster Kit (RAK3
 |---|---|---|
 | RAK Meshtastic 1W LoRa Booster Kit (RAK3401) | ~$39 | [RAK Store](https://store.rakwireless.com/products/meshtastic-1w-lora-booster-kit-rak3401) |
 | WisMesh Repeater Mini (solar enclosure donor) | ~$50-70 | [Rokland](https://store.rokland.com/products/wismesh-repeater-mini-reliable-coverage-expansion-for-smart-networks) |
-| Meshnology 5Ah battery | — | [Amazon](https://www.amazon.com/Meshnology-Rechargeable-955565-Protection-Development/dp/B0FFM9MDPR/?th=1) |
+| Meshnology 5Ah battery | n/a | [Amazon](https://www.amazon.com/Meshnology-Rechargeable-955565-Protection-Development/dp/B0FFM9MDPR/?th=1) |
 | Alfa 5.8 dBi RP-SMA whip antenna | ~$12 | [Rokland](https://store.rokland.com/collections/802-11ah-wi-fi-halow/products/alfa-network-ars-9096rp-5-dbi-indoor-antenna-for-helium-hotspots) |
 | Mast-mount bracket (STL) | print | [Download](https://u.pcloud.link/publink/show?code=XZPqoI5ZKPgwakGbUJStyvrzPUQXVjBXdPM7) |
 | Battery spacer (STL) | print | [Download](https://u.pcloud.link/publink/show?code=XZoqoI5ZKKELnYkIrap8TvU7T73gMkXI3ENV) |
 
-Plus small hardware: lever nuts (e.g. Wago) for parallel battery wiring, 3M double-sided foam tape, M3 machine screws, and hose clamps for mast mounting. A 3D printer is optional — only the mast bracket and battery spacer are printed.
+Plus small hardware: lever nuts (e.g. Wago) for parallel battery wiring, 3M double-sided foam tape, M3 machine screws, and hose clamps for mast mounting. A 3D printer is optional. Only the mast bracket and battery spacer are printed.
 
 !!! success "Community build by prayingmedic"
     This build was designed and field-tested by **prayingmedic**, a member of the Arizona Meshtastic Community. Huge thanks to him for documenting it and sharing the photos and STL files. The [full build guide](/docs/wismesh-repeater-mini-1w.html) walks through every step.
 
 !!! info "EIRP stays compliant"
-    30 dBm TX + the 5.8 dBi Alfa whip ≈ **35.8 dBm EIRP** — just under the **36 dBm** US 915 MHz ISM limit. Don't pair this build with a higher-gain antenna at full power, or you'll go over.
+    30 dBm TX + the 5.8 dBi Alfa whip ≈ **35.8 dBm EIRP**. Just under the **36 dBm** US 915 MHz ISM limit. Don't pair this build with a higher-gain antenna at full power, or you'll go over.
 
 :material-cart: **[Full Build Guide → WisMesh Repeater Mini 1W](/docs/wismesh-repeater-mini-1w.html){ .md-button .md-button--primary }**
 
@@ -246,7 +246,7 @@ The community favorite for serious coverage. Transmits at up to **36.5 dBm (4.5W
 - **Chip:** ESP32-S3 (WiFi + Bluetooth)
 - **TX Power:** Up to 36.5 dBm (4.5W)
 - **Power:** USB-C (PD) or 9-19VDC external
-- **WiFi:** Yes — MQTT gateway capable
+- **WiFi:** Yes. MQTT gateway capable
 - **Screen:** 1.3" OLED
 
 Pair with a [Rokland 5.8 dBi Fiberglass Antenna](https://store.rokland.com/products/5-8-dbi-n-male-omni-outdoor-915-mhz-antenna-large-profile-32-height-for-helium-rak-miner-2-nebra-indoor-bobcat) (~$30-40) and a waterproof enclosure. **Total build: ~$180-220.**
@@ -255,7 +255,7 @@ Pair with a [Rokland 5.8 dBi Fiberglass Antenna](https://store.rokland.com/produ
     At full 36.5 dBm output with a high-gain antenna (5.8+ dBi), you may exceed US ISM 915 MHz EIRP limits. If using a high-gain antenna, reduce TX power in Meshtastic settings to stay compliant.
 
 !!! warning "Sold out and extremely hard to get right now"
-    The Station G2 is **sold out and extremely hard to get right now.** It's our #2 rooftop pick for this reason — if you can't track one down, build the WisMesh Repeater Mini 1W above. Check [B&Q Consulting's shop](https://shop.uniteng.com/shop-2/) regularly for restocks.
+    The Station G2 is **sold out and extremely hard to get right now.** It's our #2 rooftop pick for this reason. If you can't track one down, build the WisMesh Repeater Mini 1W above. Check [B&Q Consulting's shop](https://shop.uniteng.com/shop-2/) regularly for restocks.
 
 :material-cart: [B&Q Consulting](https://shop.uniteng.com/product/meshtastic-mesh-device-station-edition/)
 
@@ -268,13 +268,13 @@ The cheapest way to get a rooftop node running. Has WiFi for MQTT (internet brid
 - **Chip:** ESP32-S3 (WiFi + Bluetooth)
 - **TX Power:** 28 dBm
 - **Power:** USB-C (plug into a wall outlet)
-- **GPS:** No (not needed — set location manually)
+- **GPS:** No (not needed. Set location manually)
 - **Solar:** Has solar panel interface
 
 Put it in a waterproof junction box (~$10), add a 915 MHz antenna (~$15-40), and run a USB cable from inside. **Total build: ~$50-80.**
 
 !!! note "Firmware and power requirements"
-    Requires Meshtastic firmware 2.7.20 or newer. TX current draw is high (960 mA) — use a quality USB power supply.
+    Requires Meshtastic firmware 2.7.20 or newer. TX current draw is high (960 mA). Use a quality USB power supply.
 
 :material-cart: [Heltec Store](https://heltec.org/project/wifi-lora-32-v4/) | [Rokland](https://store.rokland.com/products/heltec-wifi-lora-32v4-esp32s3-sx1262-lora-node-meshtastic-lorawan)
 
@@ -288,7 +288,7 @@ Don't want to build anything? These come fully assembled. Mount them, configure 
     Set your rooftop node to **CLIENT**. This is the recommended role for home installations. See the [Recommended Settings](/docs/recommended-settings.html) page for details on all roles.
 
 !!! warning "Understand Router roles before switching"
-    **Router** and **Router Late** are intended for high-elevation, permanent fixed locations with good line-of-sight — not typical home or rooftop installs. Using these roles in the wrong context can increase congestion and cause routing issues across the shared mesh. If you're considering Router or Router Late, read up on Meshtastic's guidance and ask the community on Discord before switching.
+    **Router** and **Router Late** are intended for high-elevation, permanent fixed locations with good line-of-sight. Not typical home or rooftop installs. Using these roles in the wrong context can increase congestion and cause routing issues across the shared mesh. If you're considering Router or Router Late, read up on Meshtastic's guidance and ask the community on Discord before switching.
 
     [:fontawesome-brands-discord: Ask the Community on Discord](https://discord.gg/HrKtyuFEQk){ .md-button .md-button--primary }
 
@@ -299,11 +299,11 @@ Don't want to build anything? These come fully assembled. Mount them, configure 
 | **Atlavox Beacon** | Built-in | Built-in | Yes | ~$150-200 | [Atlavox](https://atlavox.com/products/atlavox-beacon-solar-meshtastic-node) |
 | **Heltec V4 Solar Node** | 25W panel | 6x 18650 | No | ~$120-180 | [Etsy](https://www.etsy.com/listing/4310813646/outdoor-solar-2510w-meshtastic-or) |
 
-- **Best value:** SenseCAP Solar P1 Pro — 5W solar panel, 4x 18650 batteries, GPS, ~$90
-- **Easiest deploy:** WisMesh Repeater — IP67 weatherproof, mount and forget
-- **Want the Repeater Mini?** Skip the stock version and build the **1W upgrade** instead — it's [our #1 rooftop pick](/docs/wismesh-repeater-mini-1w.html): same enclosure, 6x the TX power, no soldering.
-- **Premium turnkey:** Atlavox Beacon — professional mounting hardware, dual SMA connectors, rugged build
-- **Need WiFi/MQTT?** Heltec V4 Solar Node — Heltec V4 board (+28 dBm), 25W solar panel, 6x 18650 battery bay, 5.5 dBi IP67 antenna, mast brackets included
+- **Best value:** SenseCAP Solar P1 Pro. 5W solar panel, 4x 18650 batteries, GPS, ~$90
+- **Easiest deploy:** WisMesh Repeater. IP67 weatherproof, mount and forget
+- **Want the Repeater Mini?** Skip the stock version and build the **1W upgrade** instead. It's [our #1 rooftop pick](/docs/wismesh-repeater-mini-1w.html): same enclosure, 6x the TX power, no soldering.
+- **Premium turnkey:** Atlavox Beacon. Professional mounting hardware, dual SMA connectors, rugged build
+- **Need WiFi/MQTT?** Heltec V4 Solar Node. Heltec V4 board (+28 dBm), 25W solar panel, 6x 18650 battery bay, 5.5 dBi IP67 antenna, mast brackets included
 
 !!! warning "Arizona heat and small solar panels"
     In Arizona's extreme heat (115F+), small solar panels (5W and under) may not sustain nodes long-term. For permanent Arizona deployments, consider nodes with 10W+ panels or supplement with a larger panel.
@@ -312,11 +312,11 @@ Don't want to build anything? These come fully assembled. Mount them, configure 
 
 #### :material-store: More Pre-Built Nodes on Etsy
 
-The Meshtastic community on Etsy has grown significantly. These are small-batch builders who assemble, test, and ship ready-to-deploy nodes — great if you don't want to source parts and build your own.
+The Meshtastic community on Etsy has grown significantly. These are small-batch builders who assemble, test, and ship ready-to-deploy nodes, great if you don't want to source parts and build your own.
 
 ##### PeakMesh (Highly Recommended)
 
-PeakMesh is a standout Etsy seller with consistently excellent reviews (4.8+ stars) and proven durability — customers have reported nodes surviving midwest winters, monsoon-level rain, and highway speeds. All nodes use RAK Wireless modules (nRF52840) with ALFA antennas and come fully assembled with the latest firmware.
+PeakMesh is a standout Etsy seller with consistently excellent reviews (4.8+ stars) and proven durability. Customers have reported nodes surviving midwest winters, monsoon-level rain, and highway speeds. All nodes use RAK Wireless modules (nRF52840) with ALFA antennas and come fully assembled with the latest firmware.
 
 | Model | Solar | Battery | Price | Best For | Link |
 |---|---|---|---|---|---|
@@ -333,7 +333,7 @@ PeakMesh is a standout Etsy seller with consistently excellent reviews (4.8+ sta
 | Product | What You Get | Price | Link |
 |---|---|---|---|
 | **Heltec V4 Solar Outdoor Node** | Heltec V4 (+28 dBm), 25W solar, 6x 18650 bay, 5.5 dBi IP67 antenna, mast brackets | ~$120-180 | [Etsy](https://www.etsy.com/listing/4310813646/outdoor-solar-2510w-meshtastic-or) |
-| **Heltec V4 Complete Node** | Heltec V4 board, battery, case, antenna — portable ready-to-go | ~$60-80 | [Etsy](https://www.etsy.com/listing/4439512620/heltec-v4-complete-meshtastic-node-sma) |
+| **Heltec V4 Complete Node** | Heltec V4 board, battery, case, antenna. Portable ready-to-go | ~$60-80 | [Etsy](https://www.etsy.com/listing/4439512620/heltec-v4-complete-meshtastic-node-sma) |
 | **RAK Wisblock Solar Repeater** | RAK module, 6W solar, waterproof box, 3450 mAh battery | ~$90-120 | [Etsy](https://www.etsy.com/listing/1662624760/meshtastic-node-ready-to-use-solar) |
 
 !!! tip "Buying from Etsy sellers"
@@ -343,7 +343,7 @@ PeakMesh is a standout Etsy seller with consistently excellent reviews (4.8+ sta
 
 ## :material-antenna: Antenna Guide
 
-Your antenna has the single biggest impact on range — more than the radio itself.
+Your antenna has the single biggest impact on range. More than the radio itself.
 
 #### Which Type?
 
@@ -362,18 +362,18 @@ For most Arizona rooftop nodes, an **omnidirectional fiberglass antenna** is the
 | **Rokland 8 dBi Low Profile** | 8 dBi | ~$50 | Flat terrain, max range | [Buy](https://store.rokland.com/products/8-dbi-omni-outdoor-915mhz-fiberglass-antenna-for-lora-halow-application) |
 | **ALFA AOA-915-5ACM** | 5 dBi | ~$25-35 | Compact outdoor (7" tall) | [Buy](https://store.rokland.com/products/alfa-aoa-915-5acm-5-dbi-omni-outdoor-915mhz-802-11ah-mini-antenna-for-lora-halow-application) |
 | **RAK WisMesh Blade** | ~3 dBi | ~$15-20 | Budget outdoor | [Buy](https://store.rakwireless.com/products/wismesh-antenna) |
-| **Muziworks 17cm Whip** | — | ~$12 | Handheld upgrade (SMA), best value | [Buy](https://muzi.works/products/whip-antenna-17cm) |
+| **Muziworks 17cm Whip** | n/a | ~$12 | Handheld upgrade (SMA), best value | [Buy](https://muzi.works/products/whip-antenna-17cm) |
 | **MESHTAC 4 dBi Gooseneck** | 4 dBi | ~$20-25 | Handheld upgrade (SMA) | [Buy](https://store.rokland.com/products/meshtac-gooseneck-tactical-antenna-4-dbi-gain-sma-male-915-mhz-flexible-for-meshtastic-lora) |
 
 !!! tip "Keep the cable short"
     Every foot of cable loses a little signal. Use **LMR-240 or better** cable and keep runs to **10 feet or less**. The Rokland antenna kits include quality cable in 6, 10, 15, or 25 foot lengths.
 
 !!! warning "Higher gain = narrower beam"
-    An 8-10 dBi antenna focuses signal into a narrow horizontal band — great for flat terrain but bad for hilly areas. If you're in the mountains or have significant elevation changes, stick with 3-5 dBi.
+    An 8-10 dBi antenna focuses signal into a narrow horizontal band, great for flat terrain but bad for hilly areas. If you're in the mountains or have significant elevation changes, stick with 3-5 dBi.
 
 ---
 
-!!! info "WiFi vs Bluetooth — Quick Reference"
+!!! info "WiFi vs Bluetooth. Quick Reference"
     | | **nRF52840** | **ESP32 / ESP32-S3** |
     |---|---|---|
     | **Battery life** | :material-battery-high: Great (days to weeks) | :material-battery-medium: OK (1-2 days) |
@@ -391,9 +391,9 @@ For most Arizona rooftop nodes, an **omnidirectional fiberglass antenna** is the
 |---|---|---|
 | **Rokland** | [store.rokland.com](https://store.rokland.com/) | US-based, fast shipping, great antenna selection |
 | **RAK Wireless** | [store.rakwireless.com](https://store.rakwireless.com/collections/meshtastic) | WisMesh Pocket, Repeater, Tag, 1W Booster |
-| **B&Q Consulting** | [shop.uniteng.com](https://shop.uniteng.com/) | Station G2, Nano G2 Ultra — pro RF engineering |
+| **B&Q Consulting** | [shop.uniteng.com](https://shop.uniteng.com/) | Station G2, Nano G2 Ultra. Pro RF engineering |
 | **Atlavox** | [atlavox.com](https://atlavox.com/) | Pre-built solar nodes and accessories |
-| **Muziworks** | [muzi.works](https://muzi.works/) | Cases, antennas, and the R1 Neo — assembled in USA |
+| **Muziworks** | [muzi.works](https://muzi.works/) | Cases, antennas, and the R1 Neo. Assembled in USA |
 | **PeakMesh** | [Etsy shop](https://www.etsy.com/shop/PeakMesh) | Pre-built solar nodes (RAK-based), excellent reviews, ships from FL |
 | **Seeed Studio** | [seeedstudio.com](https://www.seeedstudio.com/) | Wio Tracker, SenseCAP, Solar P1 |
 
@@ -404,8 +404,8 @@ For most Arizona rooftop nodes, an **omnidirectional fiberglass antenna** is the
 
 #### Next Steps
 
-- [How to Connect](/docs/how-to-connect.html) -- set up your new radio and join the Arizona mesh
-- [Recommended Settings](/docs/recommended-settings.html) -- configure your node for the Arizona network
+- [How to Connect](/docs/how-to-connect.html). Set up your new radio and join the Arizona mesh
+- [Recommended Settings](/docs/recommended-settings.html). Configure your node for the Arizona network
 - [Official Meshtastic Hardware List](https://meshtastic.org/docs/hardware/devices/)
 - [Meshtastic Getting Started Guide](https://meshtastic.org/docs/getting-started/)
 

--- a/docs/docs/recommended-settings.md
+++ b/docs/docs/recommended-settings.md
@@ -21,7 +21,7 @@ Choosing the right role for your device keeps the network clean and efficient.
 
 ### Client Mute
 
-**Use for: anything mobile** -- backpacks, vehicles, pocket nodes.
+**Use for: anything mobile**. Backpacks, vehicles, pocket nodes.
 
 Client Mute nodes can send and receive messages but do **not** rebroadcast other people's traffic. This is the best choice for devices that move around, since mobile rebroadcasters create unpredictable routing and extra congestion.
 
@@ -37,11 +37,11 @@ Client is the standard role. Your node will participate in the mesh by rebroadca
 ### Router and Router Late
 
 !!! warning "Understand Router roles before switching"
-    **Router** and **Router Late** are designed for nodes at **high elevation, permanent fixed locations with good line-of-sight** — think hilltops, towers, or mountain repeater sites. They aggressively rebroadcast traffic and are optimized to extend the mesh across long distances.
+    **Router** and **Router Late** are designed for nodes at **high elevation, permanent fixed locations with good line-of-sight**. Think hilltops, towers, or mountain repeater sites. They aggressively rebroadcast traffic and are optimized to extend the mesh across long distances.
 
-    Used in the wrong context — a home, an apartment, or a mobile node — these roles can cause increased congestion, routing loops, and degraded performance for everyone on the mesh. Meshtastic's own guidance is to use these roles only where they genuinely improve coverage for the wider network, not just your own reach.
+    Used in the wrong context (a home, an apartment, or a mobile node), these roles can cause increased congestion, routing loops, and degraded performance for everyone on the mesh. Meshtastic's own guidance is to use these roles only where they genuinely improve coverage for the wider network, not just your own reach.
 
-    **Before switching to Router or Router Late, make sure you understand the implications.** If you're unsure whether your location and setup are a good fit, ask the community on Discord — we're happy to help.
+    **Before switching to Router or Router Late, make sure you understand the implications.** If you're unsure whether your location and setup are a good fit, ask the community on Discord. We're happy to help.
 
     [:fontawesome-brands-discord: Ask the Community on Discord](https://discord.gg/HrKtyuFEQk){ .md-button .md-button--primary }
 
@@ -57,7 +57,7 @@ For devices that move around (in your car, backpack, pocket, etc.):
 
 | Setting | Value | Notes |
 |:--------|:------|:------|
-| **Node Info Broadcast** | `43200` sec (12 hours) | Your node info rarely changes -- no need to broadcast it often. |
+| **Node Info Broadcast** | `43200` sec (12 hours) | Your node info rarely changes. No need to broadcast it often. |
 | **Smart Broadcast** | **ON** | Automatically sends position updates when you move. |
 | Smart Broadcast Min Distance | `100` meters | Only broadcasts after moving at least 100m. |
 | Smart Broadcast Min Interval | `60` seconds | No more than one smart broadcast per minute. |
@@ -74,7 +74,7 @@ For devices that stay in one place (rooftop, home base, solar nodes):
 
 | Setting | Value | Notes |
 |:--------|:------|:------|
-| **Node Info Broadcast** | `43200` sec (12 hours) | Same as mobile -- node info does not change often. |
+| **Node Info Broadcast** | `43200` sec (12 hours) | Same as mobile. Node info does not change often. |
 | **Smart Broadcast** | **OFF** | Your node is not moving, so smart positioning is not needed. |
 | **Position Broadcast** | `43200` sec (12 hours) | Only if GPS is enabled. Your position is fixed. |
 | **GPS Update Interval** | `21600` sec (6 hours) | Minimal GPS checks since the node does not move. |
@@ -87,7 +87,7 @@ For devices that stay in one place (rooftop, home base, solar nodes):
 
 ## Neighbor Info
 
-Neighbor Info is a module that periodically broadcasts a list of your node's direct neighbors along with the signal quality (SNR) of each link. When enabled across multiple nodes, the community can build a real picture of how the mesh is connected — which helps identify coverage gaps, optimize node placement, and understand how traffic actually flows through the network.
+Neighbor Info is a module that periodically broadcasts a list of your node's direct neighbors along with the signal quality (SNR) of each link. When enabled across multiple nodes, the community can build a real picture of how the mesh is connected, which helps identify coverage gaps, optimize node placement, and understand how traffic actually flows through the network.
 
 Neighbor Info packets are small and infrequent, so the channel congestion impact is very low.
 
@@ -109,7 +109,7 @@ Neighbor Info packets are small and infrequent, so the channel congestion impact
     4. Scroll down and tap **Neighbor Info**.
     5. Toggle **Enabled** to ON.
     6. Set the **Update Interval** to `14400` (mobile) or `39600` (stationary).
-    7. Toggle **Transmit Over LoRa** to ON — this sends the neighbor info over the radio mesh and to MQTT.
+    7. Toggle **Transmit Over LoRa** to ON. This sends the neighbor info over the radio mesh and to MQTT.
     8. Tap **Send** to save the settings to your node.
 
 ??? note "How to Enable on Web Client"
@@ -129,7 +129,7 @@ Neighbor Info packets are small and infrequent, so the channel congestion impact
     # Enable the module
     meshtastic --set neighbor_info.enabled true
 
-    # Set update interval (seconds) — 14400 = 4 hours, 39600 = 11 hours
+    # Set update interval (seconds): 14400 = 4 hours, 39600 = 11 hours
     meshtastic --set neighbor_info.update_interval 14400
 
     # Enable transmit over LoRa (sends over radio AND MQTT)
@@ -148,7 +148,7 @@ Neighbor Info packets are small and infrequent, so the channel congestion impact
 
 ## MQTT
 
-MQTT lets your node upload diagnostic data to a shared server, which helps us monitor network health and see all nodes on the map. It does **not** send your personal messages or private data -- only metadata like position, telemetry, and node info.
+MQTT lets your node upload diagnostic data to a shared server, which helps us monitor network health and see all nodes on the map. It does **not** send your personal messages or private data. Only metadata like position, telemetry, and node info.
 
 !!! info "What MQTT does and does not do"
     - **Does**: Shares your node's position, battery level, signal metrics, and channel utilization with the community map and monitoring tools.
@@ -162,11 +162,11 @@ To enable MQTT uplink, you will need the community broker settings (server addre
 
 Once you have the broker details:
 
-1. **LoRa Settings**: Enable **"OK to MQTT"** -- this allows your node's data to be uplinked.
+1. **LoRa Settings**: Enable **"OK to MQTT"**. This allows your node's data to be uplinked.
 2. **MQTT Module**: Enter the broker settings provided in Discord.
 3. **Channel Settings** (for each channel you want to uplink):
-    - **Uplink**: **ON** -- sends your node's data to the MQTT server.
-    - **Downlink**: **OFF** -- prevents MQTT messages from being injected back into the radio mesh.
+    - **Uplink**: **ON**. Sends your node's data to the MQTT server.
+    - **Downlink**: **OFF**. Prevents MQTT messages from being injected back into the radio mesh.
 
 !!! warning "Always keep Downlink OFF"
     Downlinking from MQTT into the primary channel floods the radio mesh with traffic from the internet. Keep downlink disabled unless you have a specific reason and have discussed it with the community.

--- a/docs/docs/recommended_configuration_settings.md
+++ b/docs/docs/recommended_configuration_settings.md
@@ -49,7 +49,7 @@ These recommendations are based on real-world use and shared experiences within 
 |--------:|:------------------|:------|
 | **Device metrics update interval** | `3600` seconds (1 hour) | Consider `1800` (30 min) when testing or monitoring new devices. |
 | **Environment metrics update interval** | `3600` seconds (1 hour) | Disable if you’re not using environmental sensors. |
-| **Power metrics module** | `False` | For advanced setups with I²C sensors—usually not needed. |
+| **Power metrics module** | `False` | For advanced setups with I²C sensors, usually not needed. |
 
 > ℹ️ *If you don’t use temperature, air quality, or similar sensors, it’s best to turn off the corresponding modules to reduce bandwidth usage.*
 

--- a/docs/docs/suggested_channels.md
+++ b/docs/docs/suggested_channels.md
@@ -8,7 +8,7 @@ Channels are how Meshtastic groups conversations on the mesh. Every node listens
 **primary** channel plus any **secondary** channels you add, and each channel has its own
 name and encryption key so the right messages reach the right people.
 
-Adding the channels below lets you join the wider **azmsh.net** community — chat on the
+Adding the channels below lets you join the wider **azmsh.net** community. Chat on the
 Arizona channel, watch the weather roll in from rooftop stations, keep an eye on traffic, and
 even play a little trivia. Everything here is shared publicly so anyone in the community can
 hop on.
@@ -17,7 +17,7 @@ hop on.
 
     - **Channel names are case-sensitive.** `Weather` and `weather` are *not* the same channel.
     - **Keys must match exactly.** Copy the key from the table below character-for-character.
-      They're short, public, pre-shared keys (PSKs) — that's by design for community channels.
+      They're short, public, pre-shared keys (PSKs). That's by design for community channels.
 
 ---
 
@@ -32,7 +32,7 @@ find the **Channels** editor, add a channel, and enter the **Name** and **Key** 
     1. Open the **Meshtastic** app and make sure your node is connected over Bluetooth.
     2. Tap the **Settings** tab, then open **Channels**.
     3. Tap the **+** (add) button to create a new channel.
-    4. Enter the **Channel Name** exactly as shown in the table — remember it's
+    4. Enter the **Channel Name** exactly as shown in the table. Remember it's
        **case-sensitive**.
     5. Enter the **Key** (PSK) from the table. On Android the key size is taken from the
        key you paste, so just paste it in exactly as written.
@@ -40,14 +40,14 @@ find the **Channels** editor, add a channel, and enter the **Name** and **Key** 
     7. Tap **Save** / the send button to write the channel to your node.
 
     > To use **MediumFast** as your primary channel, you can leave the primary channel's
-    > name **blank** — an empty primary name is the `default` channel.
+    > name **blank**. An empty primary name is the `default` channel.
 
 ??? note "iOS / iPadOS / macOS"
 
     1. Open the **Meshtastic** app and connect to your node.
     2. Go to **Settings → Radio Configuration → Channels**.
     3. Tap **Add Channel** (the **+** button).
-    4. Enter the **Channel Name** exactly as shown in the table — it's **case-sensitive**.
+    4. Enter the **Channel Name** exactly as shown in the table. It's **case-sensitive**.
     5. Set the **Key Size** to match the **Size** column in the table:
         - `Default` → leave the size at **Default (1 byte)**.
         - `1-byte` → choose the **1 byte** size.
@@ -55,7 +55,7 @@ find the **Channels** editor, add a channel, and enter the **Name** and **Key** 
     7. Tap **Save**, then make sure you **send the configuration** back to your node.
 
     > To use **MediumFast** as your primary channel, you can leave the primary channel's
-    > name **blank** — an empty primary name is the `default` channel.
+    > name **blank**. An empty primary name is the `default` channel.
 
 ??? note "Other (Web Client / Apple Watch / CLI)"
 
@@ -67,7 +67,7 @@ find the **Channels** editor, add a channel, and enter the **Name** and **Key** 
 
     **Apple Watch**
 
-    The Watch app mirrors the channels already configured on your paired node — add channels
+    The Watch app mirrors the channels already configured on your paired node. Add channels
     on your iPhone first (see the iOS steps above) and they'll sync to the Watch.
 
     **Meshtastic CLI**
@@ -81,25 +81,25 @@ find the **Channels** editor, add a channel, and enter the **Name** and **Key** 
     ```
 
     Adjust the `--ch-index` and values for each channel you want. Use the exact names and keys
-    from the table — names are case-sensitive.
+    from the table. Names are case-sensitive.
 
 ---
 
 ## The Channels
 
 Add any of these to join the conversation. Keys are shown in monospace so you can tell them
-apart at a glance (`AQ==` vs `Ww==`). The table scrolls sideways on small screens — swipe to
+apart at a glance (`AQ==` vs `Ww==`). The table scrolls sideways on small screens. Swipe to
 see every column.
 
 | Channel Name (case sensitive) | Key | Size (iOS only) | Description |
 |:------------------------------|:----|:----------------|:------------|
 | `MediumFast` | `AQ==` | Default | The default primary MediumFast channel. Name can also be left blank. |
-| `azmsh` | `AQ==` | Default | The Arizona channel. Great for running tests and general chatter. |
-| `Weather` | `Ww==` | 1-byte | Users post from their weather stations on their roofs. Great for checking the weather every hour and making sure your node is consistently receiving. |
+| `azmsh` | `AQ==` | Default | The Arizona channel, great for running tests and general chatter. |
+| `Weather` | `Ww==` | 1-byte | Users post from their weather stations on their roofs, great for checking the weather every hour and making sure your node is consistently receiving. |
 | `Traffic` | `TQ==` | 1-byte | Local traffic reports along with waypoints showing where there is traffic on the map. |
 | `Trivia` | `MQ==` | 1-byte | Play trivia with your fellow users. Type `!help` in the channel to learn how to play. |
 
 !!! question "Need a hand?"
 
     Stuck getting a channel to show up? Hop into our [Discord](https://discord.gg/HrKtyuFEQk)
-    or [reach out](../reach_out.md) — someone in the community is always happy to help.
+    or [reach out](../reach_out.md). Someone in the community is always happy to help.

--- a/docs/docs/what-now.md
+++ b/docs/docs/what-now.md
@@ -2,78 +2,78 @@
 hide:
   - navigation
 title: What Now?
-description: You set up your node and configured your settings — now how do you check if anyone can hear you? The post-setup playbook for new Arizona Meshtastic operators.
+description: You set up your node and configured your settings. Now how do you check if anyone can hear you? The post-setup playbook for new Arizona Meshtastic operators.
 ---
 
 # What Now?
 
-So you've got your node set up, the app downloaded, all your settings configured. You connected. **Now what? How do you know if it's actually working — if anyone out there can hear you?**
+So you've got your node set up, the app downloaded, all your settings configured. You connected. **Now what? How do you know if it's actually working, if anyone out there can hear you?**
 
-This page is the moment right after [How to Connect](/docs/how-to-connect.html) — your radio is on, your settings are dialed in, and you're staring at the screen wondering: *did I do this right?*
+This page is the moment right after [How to Connect](/docs/how-to-connect.html). Your radio is on, your settings are dialed in, and you're staring at the screen wondering: *did I do this right?*
 
 Here's how to find out.
 
 ---
 
-## Step 1 — Say "test" on the Mesh
+## Step 1. Say "test" on the Mesh
 
-Meshtastic is part art and part science. The art part is trying a lot of things and testing to see what works — everyone's setup and location is different.
+Meshtastic is part art and part science. The art part is trying a lot of things and testing to see what works. Everyone's setup and location is different.
 
 1. Type `test` in the **Primary MediumFast** channel. Send it. (Send it as many times as you want.)
 2. A lot of our users run **MeshMonitor** which will respond automatically with a tapback emoji:
-   - :one: :two: :three: :four: :five: :six: :seven: — how many hops away that user is from you
-   - :asterisk: — direct hit (no hops, they heard you straight)
-3. **Got tapbacks? Congrats — you're on the mesh.** Skip to [Step 4](#step-4-claim-your-node-opt-in-for-diagnostics).
+   - :one: :two: :three: :four: :five: :six: :seven:. How many hops away that user is from you
+   - :asterisk:. Direct hit (no hops, they heard you straight)
+3. **Got tapbacks? Congrats. You're on the mesh.** Skip to [Step 4](#step-4-claim-your-node-opt-in-for-diagnostics).
 4. **No tapbacks?** Don't panic. Keep reading.
 
 ---
 
-## Step 2 — Not Getting Responses? Move Around.
+## Step 2. Not Getting Responses? Move Around.
 
 If `test` is getting crickets, the most common fixes are physical, not technical.
 
-1. **Try different locations.** Inside vs outside makes a huge difference. Near a window vs interior wall — also big.
-2. **Get higher.** **Height is might.** Roof, balcony, second floor — anywhere that gives your antenna line-of-sight to the sky and the surrounding terrain.
+1. **Try different locations.** Inside vs outside makes a huge difference. Near a window vs interior wall. Also big.
+2. **Get higher.** **Height is might.** Roof, balcony, second floor. Anywhere that gives your antenna line-of-sight to the sky and the surrounding terrain.
 3. **Step outside completely.** Even a 30-second outdoor test will tell you whether your indoor location is the problem.
-4. **Try at different times of day.** The mesh ebbs and flows — if no one's around when you test, you'll hear nothing.
+4. **Try at different times of day.** The mesh ebbs and flows. If no one's around when you test, you'll hear nothing.
 
 Keep doing the above until you see something land. Try every location, see what works best for you.
 
 ---
 
-## Step 3 — Still Nothing? Check Your Settings.
+## Step 3. Still Nothing? Check Your Settings.
 
-The **#1 issue** we see new operators run into is missing a setting — or turning something on that shouldn't be on.
+The **#1 issue** we see new operators run into is missing a setting. Or turning something on that shouldn't be on.
 
 Make sure every setting on the [Recommended Settings](/docs/recommended-settings.html) page is configured correctly, and nothing else.
 
 !!! tip "When in doubt, leave it alone"
-    If you aren't fully sure what a setting does, don't mess with it. If you want someone to check your settings, start a thread in **#i-need-help** on Discord — we're happy to take a look.
+    If you aren't fully sure what a setting does, don't mess with it. If you want someone to check your settings, start a thread in **#i-need-help** on Discord. We're happy to take a look.
 
 ### Still receiving or transmitting unreliably?
 
-A lot of solar and battery-powered nodes transmit at very low wattage — **0.05W to 0.5W**. If you've tried every location, gotten your node as high as possible, and confirmed your settings — it might be time to look at the **1W and higher** options on our [Recommended Hardware](/docs/recommended-hardware.html) page.
+A lot of solar and battery-powered nodes transmit at very low wattage: **0.05W to 0.5W**. If you've tried every location, gotten your node as high as possible, and confirmed your settings, it might be time to look at the **1W and higher** options on our [Recommended Hardware](/docs/recommended-hardware.html) page.
 
 A better antenna is often the **single biggest** improvement you can make before upgrading the radio itself.
 
 ---
 
-## Step 4 — Claim Your Node + Opt In for Diagnostics
+## Step 4. Claim Your Node + Opt In for Diagnostics
 
 Now that you're heard on the mesh, plug into the community side.
 
-**Claim your node.** Type `/node claim` in Discord. This helps others know the node is yours — they can tag you when they have questions, hear you on the air, or want to know if you can hear them.
+**Claim your node.** Type `/node claim` in Discord. This helps others know the node is yours. They can tag you when they have questions, hear you on the air, or want to know if you can hear them.
 
 **Opt in for diagnostic data.** Click the :pie: reaction in the **#getting-started** channel on Discord. Opting in unlocks:
 
 - More diagnostic data on your node
-- Access to [view.azmsh.net](https://view.azmsh.net) — our community map and MQTT diagnostics tool
+- Access to [view.azmsh.net](https://view.azmsh.net). Our community map and MQTT diagnostics tool
 
 [:fontawesome-brands-discord: Join the Discord](https://discord.gg/HrKtyuFEQk){ .md-button .md-button--primary }
 
 ---
 
-## Step 5 — Check Your Messages and Trace Routes
+## Step 5. Check Your Messages and Trace Routes
 
 Once you've opted in, search for your node on [view.azmsh.net/nodelist](https://view.azmsh.net/nodelist) to see what's actually happening on the air.
 
@@ -81,24 +81,24 @@ Once you've opted in, search for your node on [view.azmsh.net/nodelist](https://
   <a href="../assets/images/what-now-nodelist-trace-routes.jpeg" class="glightbox" data-description="Screenshot of view.azmsh.net/nodelist with the Traceroute button highlighted in red and a text message ID highlighted in blue.">
     <img src="../assets/images/what-now-nodelist-trace-routes.jpeg" alt="Screenshot of view.azmsh.net/nodelist with the Traceroute button highlighted in red and a text message ID highlighted in blue." style="width: 100%; height: auto;">
   </a>
-  <figcaption style="text-align: center; font-size: 0.85em; opacity: 0.75;">view.azmsh.net/nodelist — click to enlarge</figcaption>
+  <figcaption style="text-align: center; font-size: 0.85em; opacity: 0.75;">view.azmsh.net/nodelist. Click to enlarge</figcaption>
 </figure>
 
-- **Red (Traceroutes):** Click the arrow next to the trace routes and it'll show you the path your trace routes took — and when others trace route you. You can run trace routes by clicking on a node in the node list, scrolling down, and tapping **Trace Route**. You'll get a cool graph of where your trace route went trying to hit that node and get back home. You can also see these in **#traceroutes** on Discord.
+- **Red (Traceroutes):** Click the arrow next to the trace routes and it'll show you the path your trace routes took. And when others trace route you. You can run trace routes by clicking on a node in the node list, scrolling down, and tapping **Trace Route**. You'll get a cool graph of where your trace route went trying to hit that node and get back home. You can also see these in **#traceroutes** on Discord.
 - **Blue (Message stats):** Click the number ID for any text message you sent to see the stats for that specific message, including which nodes it hit on the way. You can also see your messages in **#messages**.
 
-Here's what success looks like — on the MeshView map and in the Meshtastic app itself. The map shows each hop along the trace-route path; the app screenshot shows the tapback responses to a `test` message, with the **number emoji** telling you how many hops away that node was from you when they heard you. Tap any image to enlarge.
+Here's what success looks like. On the MeshView map and in the Meshtastic app itself. The map shows each hop along the trace-route path; the app screenshot shows the tapback responses to a `test` message, with the **number emoji** telling you how many hops away that node was from you when they heard you. Tap any image to enlarge.
 
 <div style="display: flex; flex-wrap: wrap; gap: 16px; align-items: flex-start; justify-content: center;">
   <figure style="flex: 1 1 200px; max-width: 280px; margin: 0;">
     <a href="../assets/images/what-now-traceroute-example-meshview.jpeg" class="glightbox" data-description="Example MeshView map showing a successful trace route across the Arizona mesh.">
-      <img src="../assets/images/what-now-traceroute-example-meshview.jpeg" alt="Example MeshView map showing a successful trace route across the Arizona mesh — colored markers in Phoenix metro plus a Tucson cluster, numbers indicating hop counts." style="width: 100%; height: auto;">
+      <img src="../assets/images/what-now-traceroute-example-meshview.jpeg" alt="Example MeshView map showing a successful trace route across the Arizona mesh. Colored markers in Phoenix metro plus a Tucson cluster, numbers indicating hop counts." style="width: 100%; height: auto;">
     </a>
     <figcaption style="text-align: center; font-size: 0.85em; opacity: 0.75;">Trace route on the MeshView map</figcaption>
   </figure>
   <figure style="flex: 1 1 200px; max-width: 280px; margin: 0;">
-    <a href="../assets/images/what-now-meshtastic-app-tapbacks.jpeg" class="glightbox" data-description="Meshtastic app — tapback responses to a Test message.">
-      <img src="../assets/images/what-now-meshtastic-app-tapbacks.jpeg" alt="Meshtastic app screenshot showing a 'Test' message marked Acknowledged with four tapback responses — node IDs 0b3b, 2ef0, JICH, 82d0 each with a number emoji (2, 2, 3, 2) showing hop count." style="width: 100%; height: auto;">
+    <a href="../assets/images/what-now-meshtastic-app-tapbacks.jpeg" class="glightbox" data-description="Meshtastic app. Tapback responses to a Test message.">
+      <img src="../assets/images/what-now-meshtastic-app-tapbacks.jpeg" alt="Meshtastic app screenshot showing a 'Test' message marked Acknowledged with four tapback responses. Node IDs 0b3b, 2ef0, JICH, 82d0 each with a number emoji (2, 2, 3, 2) showing hop count." style="width: 100%; height: auto;">
     </a>
     <figcaption style="text-align: center; font-size: 0.85em; opacity: 0.75;">Tapbacks in the Meshtastic app (number = hops away)</figcaption>
   </figure>
@@ -106,22 +106,22 @@ Here's what success looks like — on the MeshView map and in the Meshtastic app
 
 ### What a successful traceroute looks like in the Meshtastic app
 
-You can run a traceroute directly from the **Meshtastic app** itself (Android, iOS, or web). Tap a node in your node list, scroll down, hit **Trace Route**, and you'll get a result — every hop on the way out, every hop on the way back, with the signal strength (dB) at each step. Green = strong signal, yellow/red = weak.
+You can run a traceroute directly from the **Meshtastic app** itself (Android, iOS, or web). Tap a node in your node list, scroll down, hit **Trace Route**, and you'll get a result. Every hop on the way out, every hop on the way back, with the signal strength (dB) at each step. Green = strong signal, yellow/red = weak.
 
 You can also see your traceroutes on [view.azmsh.net](https://view.azmsh.net) as a network graph. The **filled, colored node** is the one you successfully traced to; the surrounding dashed boxes are the hops + neighbors the trace passed through or saw along the way.
 
 <div style="display: flex; flex-wrap: wrap; gap: 16px; align-items: flex-start; justify-content: center;">
   <figure style="flex: 1 1 200px; max-width: 240px; margin: 0;">
-    <a href="../assets/images/what-now-traceroute-android-app.png" class="glightbox" data-description="Meshtastic app — successful traceroute with outbound + return path and per-hop dB.">
-      <img src="../assets/images/what-now-traceroute-android-app.png" alt="Meshtastic app traceroute result — outbound path with dB values per hop, return path, duration 11.5s." style="width: 100%; height: auto;">
+    <a href="../assets/images/what-now-traceroute-android-app.png" class="glightbox" data-description="Meshtastic app. Successful traceroute with outbound + return path and per-hop dB.">
+      <img src="../assets/images/what-now-traceroute-android-app.png" alt="Meshtastic app traceroute result. Outbound path with dB values per hop, return path, duration 11.5s." style="width: 100%; height: auto;">
     </a>
     <figcaption style="text-align: center; font-size: 0.85em; opacity: 0.75;">In-app traceroute result (Android shown; iOS + web work the same)</figcaption>
   </figure>
   <figure style="flex: 1 1 200px; max-width: 320px; margin: 0;">
-    <a href="../assets/images/what-now-traceroute-meshview-graph.png" class="glightbox" data-description="MeshView network graph — solid colored node = successful traceroute target; dashed nodes = hops/neighbors along the path.">
+    <a href="../assets/images/what-now-traceroute-meshview-graph.png" class="glightbox" data-description="MeshView network graph. Solid colored node = successful traceroute target; dashed nodes = hops/neighbors along the path.">
       <img src="../assets/images/what-now-traceroute-meshview-graph.png" alt="MeshView graph view of a traceroute from mian t1000e through Tower Climber down to Roadrunner Ridge (the solid green node = successful hit), with neighbor branches to Empire Mountains + Bubba base visible." style="width: 100%; height: auto;">
     </a>
-    <figcaption style="text-align: center; font-size: 0.85em; opacity: 0.75;">A different traceroute viewed as a graph on view.azmsh.net — solid colored node = successful target</figcaption>
+    <figcaption style="text-align: center; font-size: 0.85em; opacity: 0.75;">A different traceroute viewed as a graph on view.azmsh.net. Solid colored node = successful target</figcaption>
   </figure>
 </div>
 
@@ -129,7 +129,7 @@ You can also see your traceroutes on [view.azmsh.net](https://view.azmsh.net) as
 
 ## You're Talking on the Mesh!
 
-**Nice job — you did it!** :tada:
+**Nice job. You did it!** :tada:
 
 Here's what to do next:
 

--- a/docs/docs/wismesh-repeater-mini-1w.md
+++ b/docs/docs/wismesh-repeater-mini-1w.md
@@ -2,24 +2,24 @@
 hide:
   - navigation
 title: WisMesh Repeater Mini 1W Build Guide
-description: A complete, beginner-friendly build guide for the WisMesh Repeater Mini 1W — a self-sustaining 1 watt solar Meshtastic rooftop node. A community build by prayingmedic.
+description: A complete, beginner-friendly build guide for the WisMesh Repeater Mini 1W. A self-sustaining 1 watt solar Meshtastic rooftop node. A community build by prayingmedic.
 ---
 
-# :material-tools: WisMesh Repeater Mini 1W — Solar Build Guide
+# :material-tools: WisMesh Repeater Mini 1W. Solar Build Guide
 
-A complete, step-by-step guide to building a **1 watt (30 dBm) solar-powered rooftop node** that runs itself off the sun, 24/7. This is our **#1 recommended rooftop node** — and you don't need to solder a single thing to build it.
+A complete, step-by-step guide to building a **1 watt (30 dBm) solar-powered rooftop node** that runs itself off the sun, 24/7. This is our **#1 recommended rooftop node**. And you don't need to solder a single thing to build it.
 
 <figure style="margin: 0 auto; max-width: 420px;">
   <a href="../assets/images/wismesh-mini-1w-mast-mounted.jpg" class="glightbox" data-description="Finished WisMesh Repeater Mini 1W mounted vertically on a 10 ft mast with the Alfa 5.8 dBi whip antenna pointing up, secured with hose clamps. Build and photo by prayingmedic.">
     <img src="../assets/images/wismesh-mini-1w-mast-mounted.jpg" alt="Finished WisMesh Repeater Mini 1W node mounted vertically on a mast with a whip antenna pointing up, held by 3D-printed brackets and hose clamps." style="width: 100%; height: auto;">
   </a>
-  <figcaption style="text-align: center; font-size: 0.85em; opacity: 0.75;">The finished node on a 10 ft mast. Build &amp; photo by prayingmedic — click to enlarge.</figcaption>
+  <figcaption style="text-align: center; font-size: 0.85em; opacity: 0.75;">The finished node on a 10 ft mast. Build &amp; photo by prayingmedic. Click to enlarge.</figcaption>
 </figure>
 
 !!! success "Community build by prayingmedic :heart:"
-    This entire build — the design, every photo on this page, and the real-world field testing — is the work of community member **prayingmedic**. He figured out that the RAK 1 Watt Booster board drops right into the WisMesh Repeater Mini's solar enclosure, dialed in the battery and mounting details, and ran it on a mast for days to prove it sustains itself on solar.
+    This entire build (the design, every photo on this page, and the real-world field testing) is the work of community member **prayingmedic**. He figured out that the RAK 1 Watt Booster board drops right into the WisMesh Repeater Mini's solar enclosure, dialed in the battery and mounting details, and ran it on a mast for days to prove it sustains itself on solar.
 
-    **Huge thanks, prayingmedic.** This is his build; we're just writing it down. Got questions about the build? Ask in the [build thread on our Discord](https://discord.com/channels/1270431345734062133/1512210845558378556) — prayingmedic is in there answering questions. (New to the server? [Join here](https://discord.gg/HrKtyuFEQk) first.)
+    **Huge thanks, prayingmedic.** This is his build; we're just writing it down. Got questions about the build? Ask in the [build thread on our Discord](https://discord.com/channels/1270431345734062133/1512210845558378556). Prayingmedic is in there answering questions. (New to the server? [Join here](https://discord.gg/HrKtyuFEQk) first.)
 
 ---
 
@@ -27,36 +27,36 @@ A complete, step-by-step guide to building a **1 watt (30 dBm) solar-powered roo
 
 You're putting a **RAK 1 Watt LoRa Booster board** inside the **solar enclosure from a WisMesh Repeater Mini**. The result is a weatherproof, solar-powered node that:
 
-- **Transmits at 1 watt (30 dBm)** — about **6x the transmit power** of a typical 22 dBm node. It also *hears* better, thanks to a built-in RF filter on the radio module.
+- **Transmits at 1 watt (30 dBm)**, about **6x the transmit power** of a typical 22 dBm node. It also *hears* better, thanks to a built-in RF filter on the radio module.
 - **Runs itself off the sun.** The nRF52840 chip sips power, so the enclosure's small solar panel keeps the battery topped up and the node alive around the clock.
 - **Is legal at full power** when paired with the recommended 5.8 dBi antenna (more on the math below).
 
-**Why this build?** Our previous #1 rooftop pick, the Station G2, is **sold out and very hard to get**. This build delivers serious range and a self-sustaining solar node for around **$100-150 in parts** — and it's genuinely easy to put together.
+**Why this build?** Our previous #1 rooftop pick, the Station G2, is **sold out and very hard to get**. This build delivers serious range and a self-sustaining solar node for around **$100-150 in parts**. And it's genuinely easy to put together.
 
 !!! info "Arizona note"
-    Solar nodes shine here — pun intended. Just remember Arizona's extremes: 115F+ heat, intense UV, and monsoon storms. This enclosure is weatherproof, and prayingmedic's testing (below) shows it holds charge well even mounted in the worst-case orientation.
+    Solar nodes shine here. Pun intended. Just remember Arizona's extremes: 115F+ heat, intense UV, and monsoon storms. This enclosure is weatherproof, and prayingmedic's testing (below) shows it holds charge well even mounted in the worst-case orientation.
 
 ---
 
 ## :material-format-list-checks: Parts List
 
-Everything you need. The kit is the only "expensive" part — the rest is cheap.
+Everything you need. The kit is the only "expensive" part. The rest is cheap.
 
 | Part | What it is | Price | Buy |
 |---|---|---|---|
 | **RAK 1W LoRa Booster Kit (RAK3401)** | The brains + 1W radio. Includes the base board, nRF52840 core, the 1W LoRa module, and a USB-C cable. | ~$39 | [RAK Store](https://store.rakwireless.com/products/meshtastic-1w-lora-booster-kit-rak3401) |
-| **WisMesh Repeater Mini** | The donor — you're using its **solar enclosure, solar panel, antenna cable, and screws**. | ~$50-70 | [Rokland](https://store.rokland.com/products/wismesh-repeater-mini-reliable-coverage-expansion-for-smart-networks) |
-| **Alfa 5.8 dBi whip antenna (RP-SMA)** | The antenna. Screws right onto the enclosure's antenna cable — no adapter needed. | ~$12 | [Rokland](https://store.rokland.com/collections/802-11ah-wi-fi-halow/products/alfa-network-ars-9096rp-5-dbi-indoor-antenna-for-helium-hotspots) |
-| **Meshnology 5Ah battery** | 3.7V Li-ion pack with a JST connector. The 1W TX surge needs a real battery — see the warning below. | ~$20 | [Amazon](https://www.amazon.com/Meshnology-Rechargeable-955565-Protection-Development/dp/B0FFM9MDPR/?th=1) |
+| **WisMesh Repeater Mini** | The donor. You're using its **solar enclosure, solar panel, antenna cable, and screws**. | ~$50-70 | [Rokland](https://store.rokland.com/products/wismesh-repeater-mini-reliable-coverage-expansion-for-smart-networks) |
+| **Alfa 5.8 dBi whip antenna (RP-SMA)** | The antenna. Screws right onto the enclosure's antenna cable. No adapter needed. | ~$12 | [Rokland](https://store.rokland.com/collections/802-11ah-wi-fi-halow/products/alfa-network-ars-9096rp-5-dbi-indoor-antenna-for-helium-hotspots) |
+| **Meshnology 5Ah battery** | 3.7V Li-ion pack with a JST connector. The 1W TX surge needs a real battery. See the warning below. | ~$20 | [Amazon](https://www.amazon.com/Meshnology-Rechargeable-955565-Protection-Development/dp/B0FFM9MDPR/?th=1) |
 
 ### :material-printer-3d: 3D-Printed Parts (optional, but recommended for mast mounting)
 
-prayingmedic designed two printable parts. You don't strictly need a 3D printer to build the node — only to mast-mount it the way he did.
+prayingmedic designed two printable parts. You don't strictly need a 3D printer to build the node. Only to mast-mount it the way he did.
 
 | Part | What it's for | STL |
 |---|---|---|
 | **Mast-mount brackets** | Clip onto the back of the enclosure; accept hose clamps for vertical mast mounting. | [Download STL](https://u.pcloud.link/publink/show?code=XZPqoI5ZKPgwakGbUJStyvrzPUQXVjBXdPM7) |
-| **Battery spacer (1/8" thick, 2" square)** | Goes under the battery so it lies flat — a boss on the mounting plate makes the battery tilt without it. | [Download STL](https://u.pcloud.link/publink/show?code=XZoqoI5ZKKELnYkIrap8TvU7T73gMkXI3ENV) |
+| **Battery spacer (1/8" thick, 2" square)** | Goes under the battery so it lies flat. A boss on the mounting plate makes the battery tilt without it. | [Download STL](https://u.pcloud.link/publink/show?code=XZoqoI5ZKKELnYkIrap8TvU7T73gMkXI3ENV) |
 
 ### :material-toolbox: Small Hardware &amp; Tools
 
@@ -78,30 +78,30 @@ prayingmedic designed two printable parts. You don't strictly need a 3D printer 
 
 ---
 
-## :material-power-plug: Two Power Modes — Leave the Jumper on INTERNAL
+## :material-power-plug: Two Power Modes. Leave the Jumper on INTERNAL
 
 Before you build, understand one critical thing about this board. The 1W radio module has a small **3-pin jumper** that selects how the board is powered:
 
-- **INTERNAL** (this build) — A **3.7V Li-ion battery is mandatory.** It supplies the big current surge the 1W transmitter needs. USB-C and the solar panel only **charge** the battery — neither one can power the board on its own in this mode. The Repeater Mini's solar panel plugs into the solar header and keeps the battery full.
-- **EXTERNAL** — A 5V/1.5A supply into the jack on the back of the radio module powers everything (for AC-powered installs). **We are not using this mode.**
+- **INTERNAL** (this build). A **3.7V Li-ion battery is mandatory.** It supplies the big current surge the 1W transmitter needs. USB-C and the solar panel only **charge** the battery. Neither one can power the board on its own in this mode. The Repeater Mini's solar panel plugs into the solar header and keeps the battery full.
+- **EXTERNAL**. A 5V/1.5A supply into the jack on the back of the radio module powers everything (for AC-powered installs). **We are not using this mode.**
 
-!!! danger "Leave the jumper on INTERNAL — and the battery is NOT optional"
-    For this solar build, **leave the jumper on INTERNAL** (its default). In this mode the board **cannot run without a battery installed** — USB-C or the solar panel alone will not power it. The battery is what delivers the 1W transmit surge.
+!!! danger "Leave the jumper on INTERNAL. And the battery is NOT optional"
+    For this solar build, **leave the jumper on INTERNAL** (its default). In this mode the board **cannot run without a battery installed**. USB-C or the solar panel alone will not power it. The battery is what delivers the 1W transmit surge.
 
 ---
 
-## :material-wrench: Build It — Step by Step
+## :material-wrench: Build It. Step by Step
 
-### Step 1 — Open the enclosure and remove the stock board
+### Step 1. Open the enclosure and remove the stock board
 
-1. Using your Phillips screwdriver, remove the screws holding the clamshell enclosure together and open it up. **Keep the screws** — you'll reuse them to close it.
+1. Using your Phillips screwdriver, remove the screws holding the clamshell enclosure together and open it up. **Keep the screws**. You'll reuse them to close it.
 2. Inside you'll find the stock **RAK4631** board on a mounting plate. Gently unplug its battery/solar connectors and lift the stock board off the mounting plate. Set it aside (you won't use it for this build).
 
-### Step 2 — Mount the 1W board
+### Step 2. Mount the 1W board
 
 The 1W board is designed to drop right in.
 
-1. Place the RAK 1W board onto the **same standard mounting-plate holes** the stock board used. **No modification is needed** — the holes line up.
+1. Place the RAK 1W board onto the **same standard mounting-plate holes** the stock board used. **No modification is needed**. The holes line up.
 2. Secure it with **M3 machine screws**.
 
 <figure style="margin: 0 auto; max-width: 420px;">
@@ -111,7 +111,7 @@ The 1W board is designed to drop right in.
   <figcaption style="text-align: center; font-size: 0.85em; opacity: 0.75;">1W board mounted on the stock plate, next to the 5Ah battery. Photo: prayingmedic.</figcaption>
 </figure>
 
-### Step 3 — Prep the battery (check polarity FIRST)
+### Step 3. Prep the battery (check polarity FIRST)
 
 The standard RAK4631 build typically uses a 3Ah flatpak. For the 1W upgrade, prayingmedic recommends a **5Ah battery** to comfortably feed the bigger transmitter.
 
@@ -120,16 +120,16 @@ The standard RAK4631 build typically uses a 3Ah flatpak. For the 1W upgrade, pra
 
     **Before connecting anything**, look at your battery's leads:
 
-    - If the **red (positive)** lead is on the **inboard** side — great, you're good.
-    - If the **red (positive)** lead is on the **outboard** side — **stop.** Cut the battery leads and **swap red and black** before powering on. Plugging in reversed polarity can damage the board.
+    - If the **red (positive)** lead is on the **inboard** side, great, you're good.
+    - If the **red (positive)** lead is on the **outboard** side, **stop.** Cut the battery leads and **swap red and black** before powering on. Plugging in reversed polarity can damage the board.
 
-    In prayingmedic's close-up photo below, the **BLACK lead is on the inboard side** — that's because he swapped the leads on that pack, so on his battery **black is the positive lead.** Always verify *your* battery, not the photo.
+    In prayingmedic's close-up photo below, the **BLACK lead is on the inboard side**. That's because he swapped the leads on that pack, so on his battery **black is the positive lead.** Always verify *your* battery, not the photo.
 
 <figure style="margin: 0 auto; max-width: 420px;">
   <a href="../assets/images/wismesh-mini-1w-jst-polarity-closeup.jpg" class="glightbox" data-description="Close-up of the BATTERY and SOLAR JST sockets, RESET button, USB-C port and the + silkscreen marking on the RAK 1W board. In this photo black is positive because the leads were swapped. Build and photo by prayingmedic.">
     <img src="../assets/images/wismesh-mini-1w-jst-polarity-closeup.jpg" alt="Close-up of the BATTERY and SOLAR JST sockets, RESET button, USB-C port and the plus silkscreen on the RAK 1W board." style="width: 100%; height: auto;">
   </a>
-  <figcaption style="text-align: center; font-size: 0.85em; opacity: 0.75;">The BATTERY and SOLAR sockets, RESET, USB-C, and the "+" silkscreen. Note: in this photo black is positive — prayingmedic swapped the leads on this pack. Photo: prayingmedic.</figcaption>
+  <figcaption style="text-align: center; font-size: 0.85em; opacity: 0.75;">The BATTERY and SOLAR sockets, RESET, USB-C, and the "+" silkscreen. Note: in this photo black is positive. Prayingmedic swapped the leads on this pack. Photo: prayingmedic.</figcaption>
 </figure>
 
 !!! tip "Optional: dual-battery upgrade for extra runtime"
@@ -144,51 +144,51 @@ The standard RAK4631 build typically uses a 3Ah flatpak. For the 1W upgrade, pra
       <figcaption style="text-align: center; font-size: 0.85em; opacity: 0.75;">Two 5Ah packs stacked in parallel. Photo: prayingmedic.</figcaption>
     </figure>
 
-### Step 4 — Connect the battery, then the solar panel
+### Step 4. Connect the battery, then the solar panel
 
 Once polarity is verified and the battery (or stacked batteries) is secured with foam tape:
 
 1. Plug the **battery JST** into the **BATTERY** socket (the battery JST is a PH 2.0 connector).
 2. Plug the enclosure's **solar panel JST** into the **SOLAR** socket.
 
-The solar header only charges the battery — that's exactly what you want. It keeps the pack topped up so the node never runs out of juice.
+The solar header only charges the battery. That's exactly what you want. It keeps the pack topped up so the node never runs out of juice.
 
 <figure style="margin: 0 auto; max-width: 420px;">
   <a href="../assets/images/wismesh-mini-1w-internals-top.jpg" class="glightbox" data-description="Top-down view of the assembled internals: 1W board, battery, USB-C port, and JST wiring routed inside the enclosure. Build and photo by prayingmedic.">
     <img src="../assets/images/wismesh-mini-1w-internals-top.jpg" alt="Top-down view of the assembled node internals showing the board, battery, USB-C port and JST wiring." style="width: 100%; height: auto;">
   </a>
-  <figcaption style="text-align: center; font-size: 0.85em; opacity: 0.75;">Assembled internals — board, battery, and wiring. Photo: prayingmedic.</figcaption>
+  <figcaption style="text-align: center; font-size: 0.85em; opacity: 0.75;">Assembled internals. Board, battery, and wiring. Photo: prayingmedic.</figcaption>
 </figure>
 
-### Step 5 — Attach the antenna (BEFORE you ever power on)
+### Step 5. Attach the antenna (BEFORE you ever power on)
 
-The enclosure's supplied antenna cable is a **reverse-polarity SMA (RP-SMA)** connector. Rather than mess with adapters, pair it with the **Alfa 5.8 dBi whip antenna** — it screws right on and works great.
+The enclosure's supplied antenna cable is a **reverse-polarity SMA (RP-SMA)** connector. Rather than mess with adapters, pair it with the **Alfa 5.8 dBi whip antenna**. It screws right on and works great.
 
 1. Route the antenna cable to the enclosure's bulkhead.
-2. Screw the **Alfa 5.8 dBi whip** onto the RP-SMA connector — snug but don't overtighten.
+2. Screw the **Alfa 5.8 dBi whip** onto the RP-SMA connector. Snug but don't overtighten.
 
 !!! danger "NEVER power the board without an antenna attached"
-    Powering on a 1W transmitter with no antenna can **burn out the power amplifier** instantly. **Antenna first, always** — before you connect the battery's full power path, before you flash, before anything. Make this a habit.
+    Powering on a 1W transmitter with no antenna can **burn out the power amplifier** instantly. **Antenna first, always**. Before you connect the battery's full power path, before you flash, before anything. Make this a habit.
 
-### Step 6 — Flash the Meshtastic firmware
+### Step 6. Flash the Meshtastic firmware
 
-The nRF52840 chip flashes by drag-and-drop — no special software, just a web browser and the included USB-C cable. **Confirm your antenna is attached (Step 5) before this.**
+The nRF52840 chip flashes by drag-and-drop. No special software, just a web browser and the included USB-C cable. **Confirm your antenna is attached (Step 5) before this.**
 
 1. Open **[flasher.meshtastic.org](https://flasher.meshtastic.org/)** in **Chrome** or **Edge** on your computer.
 2. Plug the node into your computer with the **included USB-C cable**.
 3. **Double-tap the RESET button** on the board. The node enters **DFU mode** and mounts on your computer as a USB drive (like a flash drive).
-4. In the flasher, select the device named **`RAK3401 1W`** and pick the latest stable firmware. Download the firmware file — it will be named like **`firmware-rak3401-1watt-X.X.X.xxxxxxx.uf2`**.
+4. In the flasher, select the device named **`RAK3401 1W`** and pick the latest stable firmware. Download the firmware file. It will be named like **`firmware-rak3401-1watt-X.X.X.xxxxxxx.uf2`**.
 5. **Drag and drop that `.uf2` file onto the USB drive** the node mounted as. It will copy, the node will reboot automatically, and you're flashed.
 
 !!! info "Why drag-and-drop instead of one-click flashing?"
     This board uses the nRF52840's built-in **UF2 bootloader**. The official device target is **`rak3401-1watt`** (shown as **"RAK3401 1W"** in the flasher), and it installs by **double-tap-reset DFU + dropping the UF2** rather than a serial flash. If your browser can't drive the flasher, you can also grab the same `firmware-rak3401-1watt-*.uf2` from the [official Meshtastic firmware releases](https://github.com/meshtastic/firmware/releases) and drag it on manually.
 
-### Step 7 — Close it up
+### Step 7. Close it up
 
 1. Tidy the wiring so nothing is pinched.
 2. Bring the clamshell halves together and drive the **supplied screws through the back half** of the clamshell to seal it.
 
-### Step 8 — Mast-mount it
+### Step 8. Mast-mount it
 
 1. Attach the **3D-printed brackets** to the back of the enclosure with **M3 machine screws**.
 2. Run **hose clamps** through the brackets and around your mast, then tighten.
@@ -202,19 +202,19 @@ The nRF52840 chip flashes by drag-and-drop — no special software, just a web b
 </figure>
 
 !!! tip "Alternative: magnetic mount"
-    Want to attach it to a **magnetic pole** instead? There's a community-made magnetic mount for the back of the enclosure — grab the 3D-print files and a guide in [this Discord thread](https://discord.com/channels/1270431345734062133/1473733785173622986/1473733785173622986).
+    Want to attach it to a **magnetic pole** instead? There's a community-made magnetic mount for the back of the enclosure. Grab the 3D-print files and a guide in [this Discord thread](https://discord.com/channels/1270431345734062133/1473733785173622986/1473733785173622986).
 
 !!! tip "Configure before final mounting"
-    Bluetooth range on this 1W kit can be **very short (~3-6 feet)**. Keep your phone right next to the node when configuring — or just do all your configuration on the bench **before** you put it up on the mast.
+    Bluetooth range on this 1W kit can be **very short (~3-6 feet)**. Keep your phone right next to the node when configuring, or just do all your configuration on the bench **before** you put it up on the mast.
 
 ---
 
 ## :material-cog: Configuration
 
-Flashing is not configuring — **do not skip this part.** Set the node up the same way as every other node on the Arizona mesh:
+Flashing is not configuring. **Do not skip this part.** Set the node up the same way as every other node on the Arizona mesh:
 
 1. **Follow the [How to Connect](/docs/how-to-connect.html) guide** to pair the node and get it on the mesh.
-2. **Apply everything on the [Recommended Settings](/docs/recommended-settings.html) page** — region, role, channels, and broadcast intervals all live there. Those settings keep the whole Arizona mesh healthy; this guide doesn't repeat them.
+2. **Apply everything on the [Recommended Settings](/docs/recommended-settings.html) page**. Region, role, channels, and broadcast intervals all live there. Those settings keep the whole Arizona mesh healthy; this guide doesn't repeat them.
 
 ### Settings specific to this build
 
@@ -227,14 +227,14 @@ Only a few settings differ from a standard node because of the 1W radio and sola
 | **Bluetooth** | Off if not needed | Saves power. If you turn BT off, plan to manage the node with an **admin node** remotely. |
 
 !!! warning "Don't pick Router/Router Late just because it's powerful"
-    A 1W node is tempting to set as a Router — **don't, unless your site genuinely calls for it.** Router roles are for high-elevation, permanent, line-of-sight repeater sites. For a home rooftop, stick with the role guidance on [Recommended Settings](/docs/recommended-settings.html). If you think your location qualifies, ask the community on Discord first.
+    A 1W node is tempting to set as a Router. **Don't, unless your site genuinely calls for it.** Router roles are for high-elevation, permanent, line-of-sight repeater sites. For a home rooftop, stick with the role guidance on [Recommended Settings](/docs/recommended-settings.html). If you think your location qualifies, ask the community on Discord first.
 
-!!! danger "EIRP compliance — stay legal"
+!!! danger "EIRP compliance. Stay legal"
     Your **effective radiated power** is TX power **plus** antenna gain:
 
     > 30 dBm (1W) **+** 5.8 dBi antenna **≈ 35.8 dBm EIRP**
 
-    That's **just under the 36 dBm US 915 MHz ISM limit** — so this build is compliant **as specced**, at full 30 dBm with the 5.8 dBi Alfa whip. **Do not pair full 30 dBm power with a higher-gain antenna** — you'll exceed the legal limit. If you use a bigger antenna, turn TX power down to compensate.
+    That's **just under the 36 dBm US 915 MHz ISM limit**. So this build is compliant **as specced**, at full 30 dBm with the 5.8 dBi Alfa whip. **Do not pair full 30 dBm power with a higher-gain antenna**. You'll exceed the legal limit. If you use a bigger antenna, turn TX power down to compensate.
 
 !!! tip "Cloudy weather? Back off the TX power"
     prayingmedic tested in full sun. He hasn't yet run it through an extended cloudy stretch, so for **inclement weather** a safe bet is to drop TX power to about **26-28 dBm** to be gentler on the battery. With good sun, full 30 dBm holds charge fine (see his results below).
@@ -249,11 +249,11 @@ prayingmedic mounted the node **vertically on a 10 ft mast** in **CLIENT** mode 
 - **Channel utilization:** **6-13% per day.**
 - **Battery voltage:** started at **3.82V** and stayed within a tight **3.80-3.84V** band the *entire* 5 days.
 
-**Takeaway:** With adequate sun, the state of charge holds in a very narrow band near the deployment voltage — at least through the first few weeks.
+**Takeaway:** With adequate sun, the state of charge holds in a very narrow band near the deployment voltage. At least through the first few weeks.
 
 !!! note "Things prayingmedic points out"
-    - **Horizontal mounting** (solar panel facing up) would likely harvest *more* solar than the vertical orientation he tested — so his numbers are conservative.
-    - It hasn't yet been tested through **extended cloudy weather** — that's why ~26 dBm is the safe inclement-weather setting.
+    - **Horizontal mounting** (solar panel facing up) would likely harvest *more* solar than the vertical orientation he tested. So his numbers are conservative.
+    - It hasn't yet been tested through **extended cloudy weather**. That's why ~26 dBm is the safe inclement-weather setting.
     - **Energy saving is the priority:** turn **power saving ON**, and turn **Bluetooth OFF if you don't need it** (manage settings via an **admin node** if BT is off). Keep broadcast intervals reasonable.
 
 ---
@@ -262,7 +262,7 @@ prayingmedic mounted the node **vertically on a 10 ft mast** in **CLIENT** mode 
 
 Want to go deeper on the RAK 1W kit and its power behavior? **Atlavox** has two excellent videos:
 
-- :material-play-circle: [RAK 1W Booster Deep Dive — A Use-Case Nobody's Talking About](https://www.youtube.com/watch?v=SQ8TnKPmTn4)
+- :material-play-circle: [RAK 1W Booster Deep Dive. A Use-Case Nobody's Talking About](https://www.youtube.com/watch?v=SQ8TnKPmTn4)
 - :material-play-circle: [RAK 1watt Booster Power Requirements](https://www.youtube.com/watch?v=S28xwvTSWZ8)
 
 ---
@@ -270,32 +270,32 @@ Want to go deeper on the RAK 1W kit and its power behavior? **Atlavox** has two 
 ## :material-bug: Troubleshooting &amp; Gotchas
 
 !!! warning "Node won't power on"
-    In **INTERNAL** mode, the board **needs a battery** — USB-C or solar alone won't run it. Confirm the battery is plugged in, charged, and correct polarity. Confirm the jumper is on **INTERNAL**.
+    In **INTERNAL** mode, the board **needs a battery**. USB-C or solar alone won't run it. Confirm the battery is plugged in, charged, and correct polarity. Confirm the jumper is on **INTERNAL**.
 
 !!! danger "Never test without an antenna"
     Worth repeating: powering the 1W transmitter with no antenna can fry the amplifier. Antenna on first, every time.
 
 !!! warning "Battery polarity"
-    If the node behaves oddly after a battery swap, re-verify polarity. RAK uses **positive inboard** — if your pack has red on the outboard side, you must swap the leads (prayingmedic did exactly that, which is why black is positive in his close-up).
+    If the node behaves oddly after a battery swap, re-verify polarity. RAK uses **positive inboard**. If your pack has red on the outboard side, you must swap the leads (prayingmedic did exactly that, which is why black is positive in his close-up).
 
 !!! tip "Can't connect over Bluetooth"
     BLE range on this kit is **short (~3-6 ft)**. Stand right next to the node, or configure it on the bench before mounting.
 
-!!! info "Position, antenna, cable, power — in that order"
+!!! info "Position, antenna, cable, power. In that order"
     Range comes from **height and line-of-sight first**, then antenna, then cable quality, then transmit power. The 1W boost is a real help, but it does **not** replace getting the node up high. Mount it as high as you safely can.
 
 !!! question "Stuck on something?"
-    Ask in the [build thread on our Discord](https://discord.com/channels/1270431345734062133/1512210845558378556) — prayingmedic himself is in the thread and happy to help. ([Join the server](https://discord.gg/HrKtyuFEQk) first if you're not in it yet.)
+    Ask in the [build thread on our Discord](https://discord.com/channels/1270431345734062133/1512210845558378556). Prayingmedic himself is in the thread and happy to help. ([Join the server](https://discord.gg/HrKtyuFEQk) first if you're not in it yet.)
 
 ---
 
 #### Next Steps
 
-- [Recommended Hardware](/docs/recommended-hardware.html) — see how this stacks up against other rooftop nodes
-- [Recommended Settings](/docs/recommended-settings.html) — full role and interval guidance for the Arizona mesh
-- [How to Connect](/docs/how-to-connect.html) — get your node on the Arizona mesh
-- [What Now?](/docs/what-now.html) — confirm the mesh can actually hear you
+- [Recommended Hardware](/docs/recommended-hardware.html). See how this stacks up against other rooftop nodes
+- [Recommended Settings](/docs/recommended-settings.html). Full role and interval guidance for the Arizona mesh
+- [How to Connect](/docs/how-to-connect.html). Get your node on the Arizona mesh
+- [What Now?](/docs/what-now.html). Confirm the mesh can actually hear you
 
 ---
 
-*Build, photos, and field testing by **prayingmedic**. Prices are estimates as of early 2026 and may vary — check retailer links for current pricing.*
+*Build, photos, and field testing by **prayingmedic**. Prices are estimates as of early 2026 and may vary. Check retailer links for current pricing.*

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,7 @@ hide:
   - navigation
 ---
 
-<h1>Welcome to Arizona's Meshtastic Community!</h1>
+# Welcome to Arizona's Meshtastic Community!
 
 Meshtastic is a free, open-source mesh network that lets you send text messages, share GPS locations, and communicate off-grid using small, affordable radios. No cell service, no internet, no monthly fees, no license required.
 
@@ -13,7 +13,7 @@ Whether you're brand new to radio or a seasoned operator, this is your hub to ge
 
 <span style="display: flex; align-items: center; justify-content: center; gap: 1rem;">
     [:fontawesome-brands-discord: Join us on Discord](https://discord.gg/HrKtyuFEQk){ .md-button .md-button--primary target="_blank"}
-    [:material-information-outline: Learn More](/docs/how-to-connect.html){ .md-button }
+    [:material-information-outline: Learn how to connect](/docs/how-to-connect.html){ .md-button }
 </span>
 
 <div class="grid cards" markdown>

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -1,0 +1,197 @@
+---
+title: Privacy Policy
+hide:
+  - navigation
+---
+
+# Privacy Policy
+
+_Last updated: June 8, 2026_
+
+This policy explains what information the Arizona Meshtastic Community handles
+when you visit this website (azmsh.net), sign in to our tools, or send traffic
+across the mesh that our collectors can see.
+
+We are a volunteer-run community group, not a company. We try to collect as
+little as possible and to be clear about the parts of the mesh that are public by
+design.
+
+## The short version
+
+- This website does not use cookies, analytics, or trackers.
+- To use our tools (like the map and node viewer at view.azmsh.net), you sign in
+  with Discord. Discord tells us who you are and which servers you belong to, so
+  we can confirm you are part of the community and let you in. We do not see your
+  Discord password or read your private messages.
+- The mesh data we show (nodes, positions, signal reports, telemetry, and public
+  text messages) is collected from the **public Meshtastic channel** over MQTT.
+  Traffic on that channel is not private. If you broadcast on it, treat it as
+  public.
+
+## Signing in with Discord
+
+Access to our tools is gated behind Discord. We use Discord's OAuth2 sign-in only
+to confirm who you are and that you are allowed to use the tools. We do not run
+our own password system.
+
+When you sign in, we request three Discord permissions (scopes):
+
+- **identify** lets us see your basic account, such as your Discord user ID,
+  username, and avatar.
+- **guilds** lets us see the list of Discord servers you belong to.
+- **guilds.members.read** lets us see your membership details in a server, such as
+  your roles and nickname.
+
+We use these to confirm that you are a member of the Arizona Meshtastic Community
+Discord and to check your roles so we can give you the right level of access. We
+may keep your Discord user ID to manage your access and your session. We do not
+receive your password, and we do not read your direct messages or server messages.
+
+Your use of Discord is also covered by Discord's own terms and privacy policy:
+
+- [Discord Developer Terms of Service](https://support-dev.discord.com/hc/en-us/articles/8562894815383-Discord-Developer-Terms-of-Service)
+- [Discord Privacy Policy](https://discord.com/privacy)
+
+You can review or remove our app's access at any time in your Discord account
+settings under **Authorized Apps**.
+
+## Mesh network data we collect and display
+
+Our tools display data about the Arizona Meshtastic network. That data is gathered
+by ad-hoc MQTT collectors that listen to the network. On the other end of those
+MQTT links are Meshtastic radios that people in the community operate.
+
+Meshtastic devices that are set to bridge to MQTT send their traffic to a broker,
+where our collectors can receive it. Depending on how a node is configured, that
+traffic can include:
+
+- Node information, such as the node ID and the short and long names a user chose
+- GPS position and altitude, if the node is set to share location
+- Telemetry, such as battery level, voltage, and any attached sensor readings
+- Public text messages
+- Routing, neighbor, and traceroute information
+- Signal data, such as signal-to-noise ratio and received signal strength
+
+We collect this so we can show the health of the network: which nodes are online,
+how they connect to each other, and how well the mesh is performing.
+
+### How the data reaches us
+
+A typical packet travels like this:
+
+1. A Meshtastic radio sends a packet over the air.
+2. A node on the mesh that is connected to MQTT relays that packet to an MQTT
+   broker.
+3. Our ingestion tool reads the packet from the broker and decodes it using the
+   public default key (AQ==).
+4. The decoded data is shown in our tools, such as view.azmsh.net.
+
+Our broker is set up for uploads only. Nodes can send data to it, but downlink is
+disabled, so the broker does not send anything back to nodes or the mesh, and
+people cannot pull data back out of it. Only our own ingestion tools read from the
+broker so we can display the data. **Nothing we run transmits on the network or
+changes how your node behaves.**
+
+## Important: public-channel data is not private
+
+Meshtastic's standard channels are secured only with a default encryption key
+(AQ==) that ships with every device and is publicly known. This is not unique to
+one channel. The same default key is used by the common presets, such as LongFast
+and MediumFast, whenever a channel is left on the default key. Because that key is
+public, anyone running Meshtastic can read traffic that uses it. It is not
+private, even though it is technically "encrypted."
+
+When a node is configured to uplink to MQTT, that traffic can be received by any
+collector connected to that broker, including ours and others around the world.
+Please keep this in mind:
+
+- Anything you send on the public channel can be seen by other people.
+- If your node shares its location, that location can be collected and displayed.
+- If you want privacy, do not put sensitive information on the public channel.
+
+If you connect a node to MQTT, please follow best node practices as described in
+the [Meshtastic MQTT documentation](https://meshtastic.org/docs/software/integrations/mqtt/).
+
+To learn more about how this works, see the Meshtastic documentation on
+[MQTT](https://meshtastic.org/docs/software/integrations/mqtt/) and
+[encryption](https://meshtastic.org/docs/overview/encryption/).
+
+## Your choices and control
+
+You control what your own node puts on the air. To limit what can be collected:
+
+- Turn off MQTT uplink on your node if you do not want it bridged to a broker.
+- Turn off position sharing, or reduce your location precision, if you do not
+  want your location collected.
+- Use a private channel with your own key for anything you do not want to be
+  public.
+
+If you would like us to remove specific data tied to your node or your Discord
+account from our tools, [contact us](#contact-us) and we will do our best to help.
+To help us find the right data quickly, please include:
+
+- A screenshot of the node in our tools, if you can get one.
+- The node ID and name, along with any other naming information that helps
+  identify it.
+- What you want removed: location only, text messages only, or all information
+  for the node.
+
+Note that we cannot remove data that other collectors or the wider Meshtastic
+ecosystem may have already received from the public channel.
+
+## How we share information
+
+We do not sell your information, and we do not share it for advertising. Limited
+sharing happens as a normal part of running the site and the network:
+
+- **Discord** handles sign-in, as described above.
+- **Our hosting providers** serve the website and run the tools.
+- **The public Meshtastic network** is shared by design. Public-channel traffic
+  reaches other collectors and viewers beyond us, and we do not control them.
+
+## How long we keep information
+
+Most of our tools keep mesh data for about two weeks and then let it age off
+automatically. We keep the Discord account information needed to manage your
+access for as long as you have access to the tools. If you would like your
+information removed, please reach out.
+
+## Children's privacy
+
+Our website and tools are meant for a general audience and are not directed to
+children under 13. Access to our tools requires signing in with Discord, and
+Discord's own terms require users to be at least 13 years old (or older where
+local law requires it). We do not knowingly collect personal information from
+children under 13. If you believe a child has provided us with personal
+information through our tools, please [contact us](#contact-us) and we will delete
+it.
+
+## By connecting to the network and using our tools
+
+By connecting a node that uplinks to MQTT on the public channel, or by signing in
+to and using our tools, you acknowledge and agree that:
+
+- Traffic you send on the public Meshtastic channel is public and may be
+  collected, stored, and displayed by us and by others.
+- Position, telemetry, and text data your node broadcasts on the public channel
+  may appear in our tools.
+- You are responsible for configuring your own node, including whether it shares
+  location and whether it uplinks to MQTT.
+- Our tools are provided by volunteers, as-is, with no guarantee of accuracy or
+  availability.
+- You will use the tools and the network in line with Meshtastic's guidelines and
+  applicable law, and you will not use them to harass others or to disrupt the
+  network.
+
+If you do not agree with this, please do not uplink to the public channel or use
+our tools.
+
+## Changes to this policy
+
+We may update this policy as the network and our tools change. When we make a
+meaningful change, we will update the date at the top of this page.
+
+## Contact us
+
+- **Email:** [contact@azmsh.net](mailto:contact@azmsh.net)
+- **Discord:** [Join the Arizona Meshtastic Community Discord](https://discord.gg/HrKtyuFEQk)

--- a/docs/reach_out.md
+++ b/docs/reach_out.md
@@ -17,7 +17,7 @@ Our Discord server is the most active place to connect with the Arizona Meshtast
 
 [:fontawesome-brands-discord: Join the Discord](https://discord.gg/HrKtyuFEQk){ .md-button .md-button--primary }
 
-<iframe src="https://discord.com/widget?id=1270431345734062133&theme=dark" width="350" height="500" allowtransparency="true" frameborder="0" sandbox="allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts"></iframe>
+<iframe src="https://discord.com/widget?id=1270431345734062133&theme=dark" width="350" height="500" title="Arizona Meshtastic Community Discord server widget" allowtransparency="true" frameborder="0" sandbox="allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts"></iframe>
 
 ---
 

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,57 @@
+/*
+ * Accessibility overrides
+ * ------------------------
+ * Material's "deep orange" (#FF5722) used as the link/button color only reaches
+ * ~3.6:1 contrast on white, which fails WCAG 2.1 AA (4.5:1 for normal text).
+ * The rules below darken interactive colors in light mode and lighten them in
+ * dark mode so text and links meet the AA contrast threshold in both themes.
+ */
+
+/*
+ * Header / navigation bar: Material's "deep orange" (#FF5722) header with white
+ * text only reaches ~2.78:1 — failing AA for the site title, the navigation
+ * tabs, and header links. Darkening the primary color to #c5410d brings white
+ * text to ~5:1 while keeping a recognizably orange header. Applies to both the
+ * light and dark color schemes (both use the deep-orange primary).
+ */
+[data-md-color-primary="deep-orange"] {
+  --md-primary-fg-color: #c5410d;
+  --md-primary-fg-color--light: #e2531f;
+  --md-primary-fg-color--dark: #a8350a;
+}
+
+/* Light theme: darker orange links (#bf360c ≈ 5.6:1 on white) */
+[data-md-color-scheme="default"] {
+  --md-typeset-a-color: #bf360c;
+}
+
+/* Dark theme: lighter orange links for contrast against the dark background */
+[data-md-color-scheme="slate"] {
+  --md-typeset-a-color: #ffb38a;
+}
+
+/* Primary buttons: ensure white button text meets AA against the background */
+.md-typeset .md-button--primary {
+  background-color: #bf360c;
+  border-color: #bf360c;
+}
+
+[data-md-color-scheme="slate"] .md-typeset .md-button--primary {
+  background-color: #e2531f;
+  border-color: #e2531f;
+}
+
+/*
+ * Footer links (Accessibility / Privacy Policy live in the copyright line).
+ * Use the full-strength footer text color and an underline so they read as
+ * links and keep AA contrast against the dark footer.
+ */
+.md-copyright a {
+  color: var(--md-footer-fg-color);
+  text-decoration: underline;
+}
+
+.md-copyright a:hover,
+.md-copyright a:focus {
+  color: var(--md-accent-fg-color);
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,15 +1,13 @@
 site_name: Arizona Meshtastic Community
 theme:
   name: material
+  language: en
   logo: assets/images/logo.png
   favicon: assets/images/favicon.png
   features:
     - search.suggest
     - search.highlight
     - search.share
-    - navigation.instant
-    - navigation.instant.prefetch
-    - navigation.instant.progress
     - navigation.tabs
     - navigation.tabs.sticky
   palette:
@@ -42,6 +40,12 @@ nav:
   - Host a Node: docs/host-a-node.md
   - Reach Out: reach_out.md
 
+# Accessibility and Privacy Policy are intentionally not in the top nav; they are
+# linked from the footer (see the `copyright` setting below).
+not_in_nav: |
+  /accessibility.md
+  /privacy.md
+
 plugins:
   - offline
   - search
@@ -65,10 +69,17 @@ markdown_extensions:
       emoji_index: !!python/name:material.extensions.emoji.twemoji
       emoji_generator: !!python/name:material.extensions.emoji.to_svg
 
+extra_css:
+  - stylesheets/extra.css # Accessibility (WCAG AA contrast) overrides
+
 extra_javascript:
   - assets/js/nodeData.js # Node Info
+  - assets/js/a11y.js # Skip-link focus management
 
-copyright: Copyright &copy; 2025 Arizona Meshtastic Community
+copyright: >
+  Copyright &copy; 2026 Arizona Meshtastic Community
+  &nbsp;&middot;&nbsp; <a href="/accessibility.html">Accessibility</a>
+  &nbsp;&middot;&nbsp; <a href="/privacy.html">Privacy Policy</a>
 extra:
   social:
     - icon: fontawesome/brands/discord


### PR DESCRIPTION
- Fix color contrast (header, nav tabs, links) to meet WCAG AA in both themes
- Restore the skip-to-content link on every page and move focus into content
- Add accessibility statement and privacy policy, linked from the footer
- Add a title to the Discord iframe; set page language to en
- Disable instant navigation for reliable focus and screen-reader announcements
- Remove em dashes and double-hyphen dashes across the content pages
- Add pa11y config and maintainer docs for the accessibility audit
- Update footer copyright to 2026; ignore .venv in git