### PR TITLE
ci: add pa11y soft check in GitHub Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,58 @@ jobs:
       - name: Build site
         run: mkdocs build --strict
 
+  accessibility:
+    name: Accessibility Audit (Soft Check)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install site dependencies
+        run: |
+          pip install mkdocs mkdocs-material mkdocs-minify-plugin mkdocs-git-revision-date-localized-plugin mkdocs-glightbox
+
+      - name: Install pa11y-ci
+        run: npm install -g pa11y-ci
+
+      - name: Build site
+        run: mkdocs build --strict
+
+      - name: Start local site server
+        run: python -m http.server 8000 --directory site >/tmp/pa11y-server.log 2>&1 &
+
+      - name: Wait for local site server
+        run: |
+          for i in 1 2 3 4 5; do
+            curl -fsS http://127.0.0.1:8000/ >/dev/null && exit 0
+            sleep 2
+          done
+          exit 1
+
+      - name: Run pa11y-ci
+        continue-on-error: true
+        run: pa11y-ci | tee pa11y-results.txt
+
+      - name: Upload pa11y logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pa11y-results
+          path: |
+            pa11y-results.txt
+            /tmp/pa11y-server.log
+
   deploy:
     name: Deploy to GitHub Pages
     needs: build

--- a/ACCESSIBILITY.md
+++ b/ACCESSIBILITY.md
@@ -28,6 +28,20 @@ and the documented rule exceptions below. A clean run reports
 > libpango-1.0-0 libcairo2 libnss3 libnspr4 libdrm2 libxshmfence1 libx11-xcb1
 > libasound2t64`
 
+## GitHub Actions soft check
+
+The GitHub Actions workflow also runs `pa11y-ci` against the built `site/`
+output on every push and pull request.
+
+- The site is built with `mkdocs build --strict`
+- The generated `site/` directory is served locally inside the runner
+- `pa11y-ci` runs against the URLs in [`.pa11yci`](.pa11yci)
+- The audit step is intentionally **non-blocking** (`continue-on-error: true`)
+
+That means accessibility regressions are still surfaced in CI, but they do not
+stop deploys or merges while you are treating the audit as advisory. If you want
+to make it blocking later, remove `continue-on-error: true` from the workflow.
+
 ## Documented rule exceptions (`ignore` in `.pa11yci`)
 
 These three findings are produced by **Material for MkDocs' own UI controls**,


### PR DESCRIPTION
## CI/CD accessibility check summary

I added a new non-blocking accessibility audit job to the GitHub Actions workflow.

### What changed

- Kept the existing `build` job unchanged so `mkdocs build --strict` still validates the site as before
- Added a separate `accessibility` job that runs on every push and pull request
- Installed both the MkDocs Python dependencies and Node.js so `pa11y-ci` can run in GitHub Actions
- Built the site and served the generated `site/` directory locally inside the GitHub Actions runner
- Ran `pa11y-ci` against the existing `.pa11yci` configuration in the repo root
- Marked the `pa11y-ci` step with `continue-on-error: true` so it behaves as a soft check
- Uploaded the `pa11y` results and local server log as workflow artifacts for troubleshooting
- Left the `deploy` job unchanged, so deployment behavior to GitHub Pages stays the same

### Result

Accessibility issues now show up in CI as advisory feedback without blocking merges or deploys. This gives the team visibility into regressions while keeping the current release flow intact.

### Docs update

- Updated `ACCESSIBILITY.md` to document that `pa11y-ci` now runs automatically in GitHub Actions as a soft check