### PR TITLE
Add azmsh.net/ch short URL for the Suggested Channels page

### DIFF
--- a/docs/ch/index.html
+++ b/docs/ch/index.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Suggested Channels - Arizona Meshtastic Community</title>
+
+    <!--
+      Short-URL redirect stub: azmsh.net/ch -> /docs/suggested_channels.html
+
+      This is raw HTML rather than a Markdown page on purpose. The `offline`
+      plugin in mkdocs.yml turns off directory URLs, so a `ch.md` would build
+      to `/ch.html` (azmsh.net/ch.html, 17 chars) instead of `/ch`
+      (azmsh.net/ch, 12 chars). MkDocs copies non-Markdown files from docs/
+      through verbatim, so this file lands at /ch/index.html and GitHub Pages
+      serves it for /ch (301 -> /ch/).
+
+      Those few bytes matter: this link is meant to fit inside Meshtastic
+      auto-acknowledgement messages, which are hard-capped at 237 UTF-8 bytes.
+
+      Reverting is just deleting this directory.
+    -->
+
+    <meta http-equiv="refresh" content="0; url=../docs/suggested_channels.html">
+    <link rel="canonical" href="https://azmsh.net/docs/suggested_channels.html">
+    <meta name="robots" content="noindex, follow">
+
+    <style>
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+          Helvetica, Arial, sans-serif;
+        line-height: 1.6;
+        margin: 0;
+        padding: 3rem 1.5rem;
+        color: #1a1a1a;
+        background: #fff;
+      }
+      main { max-width: 34rem; margin: 0 auto; }
+      a { color: #bf360c; }
+      @media (prefers-color-scheme: dark) {
+        body { color: #e6e6e6; background: #1a1a1a; }
+        a { color: #ffab91; }
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Suggested Channels</h1>
+      <p>
+        Taking you to the Suggested Channels page. If nothing happens,
+        <a href="../docs/suggested_channels.html">open it here</a>.
+      </p>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
## What this adds

A single new file, `docs/ch/index.html`, that makes `azmsh.net/ch` redirect to `https://azmsh.net/docs/suggested_channels.html`.

## Why

The AZ Mesh G2 Base node auto-acknowledges incoming Meshtastic messages, and we'd like that acknowledgement to point people at the Suggested Channels page so newcomers can find the community channels on their own.

The catch is budget. Meshtastic text payloads are hard-capped at 237 UTF-8 bytes, and the auto-ack path **rejects** an over-length message rather than truncating it — so a link that doesn't fit doesn't just get cut short, the whole ack fails to send. Every character is a real constraint.

- Full URL: `https://azmsh.net/docs/suggested_channels.html` — **46 characters**, roughly a quarter of the usable message.
- `azmsh.net/ch` — **12 characters**.

That difference buys back room for actual words in the ack.

## Alternatives considered

**A third-party shortener (bit.ly and friends.)** Counterintuitively this is *longer* — a bit.ly link runs ~14 characters, so it costs more bytes than the thing it's replacing. It also routes every click through a third party and logs it there. Keeping the redirect on `azmsh.net` is both smaller and keeps visitor data on our own infrastructure.

**A Cloudflare redirect rule.** This would mean flipping `azmsh.net` to proxied. That's a much bigger blast radius — TLS, caching, and every existing record — in exchange for a one-line redirect. Not a trade worth making here.

## Implementation notes

It's raw HTML rather than a Markdown page on purpose. The `offline` plugin in `mkdocs.yml` disables directory URLs, so a `ch.md` would build to `/ch.html` — `azmsh.net/ch.html` is 17 characters, which gives back most of what we're trying to save. MkDocs copies non-Markdown files out of `docs/` verbatim, so this lands at `/ch/index.html` and GitHub Pages serves it for `/ch` (301 to `/ch/`).

The stub also includes:

- `rel=canonical` pointing at the real Suggested Channels page.
- `noindex, follow` so it doesn't compete with that page in search results.
- A visible fallback link in the body, for anything that doesn't honour meta-refresh.
- A relative link target (`../docs/suggested_channels.html`) rather than an absolute one, so it resolves correctly on fork/preview builds served from a sub-path as well as on `azmsh.net`.

There's a comment block in the file explaining the raw-HTML choice, so it doesn't look like an accident to whoever finds it next.

## Risk

Additive and reversible. `/ch`, `/c`, and `/channels` all return 404 today, so there's no collision — re-verified against the live site immediately before opening this PR. Deleting `docs/ch/` removes the feature entirely; nothing else changes.

## Testing

Built locally with `mkdocs build --strict` (same command CI runs) — passes. Diffed the built site against a baseline build without this change: the **only** difference in the entire output tree is the new `ch/` directory, and `docs/suggested_channels.html` is byte-identical. Served the build locally and confirmed the chain end to end: `/ch` → 301 → `/ch/` → 200, meta-refresh target resolves to the Suggested Channels page (200, correct title). The stub does not appear in `sitemap.xml`.

## One note on the branch

This branch is cut from the fork's `main`, which is currently a few commits behind upstream, because the token I have can't push branches carrying the workflow changes in between. The fork's `main` is a strict ancestor of upstream `main`, so the diff here is exactly the one new file and it merges cleanly — but wanted to flag it rather than have it look odd. Happy to re-cut from a synced `main` if you'd prefer.