### PR TITLE
fix(footer): resolve Accessibility/Privacy links at any base path

### DIFF
--- a/docs/docs/recommended-hardware.md
+++ b/docs/docs/recommended-hardware.md
@@ -38,7 +38,7 @@ New to Meshtastic? Here's what to buy. No monthly fees, no subscriptions. Just a
 
     **~$125-150 in parts**. Every step is documented for first-time builders.
 
-    [:material-tools: Full Build Guide](/docs/wismesh-repeater-mini-1w.html){ .md-button .md-button--primary }
+    [:material-tools: Full Build Guide](wismesh-repeater-mini-1w.md){ .md-button .md-button--primary }
 
 </div>
 
@@ -230,12 +230,12 @@ Our #1 rooftop node. A community build that puts the RAK 1W Booster Kit (RAK3401
 Plus small hardware: lever nuts (e.g. Wago) for parallel battery wiring, 3M double-sided foam tape, M3 machine screws, and hose clamps for mast mounting. A 3D printer is optional. Only the mast bracket and battery spacer are printed.
 
 !!! success "Community build by prayingmedic"
-    This build was designed and field-tested by **prayingmedic**, a member of the Arizona Meshtastic Community. Huge thanks to him for documenting it and sharing the photos and STL files. The [full build guide](/docs/wismesh-repeater-mini-1w.html) walks through every step.
+    This build was designed and field-tested by **prayingmedic**, a member of the Arizona Meshtastic Community. Huge thanks to him for documenting it and sharing the photos and STL files. The [full build guide](wismesh-repeater-mini-1w.md) walks through every step.
 
 !!! info "EIRP stays compliant"
     30 dBm TX + the 5.8 dBi Alfa whip ≈ **35.8 dBm EIRP**. Just under the **36 dBm** US 915 MHz ISM limit. Don't pair this build with a higher-gain antenna at full power, or you'll go over.
 
-:material-cart: **[Full Build Guide → WisMesh Repeater Mini 1W](/docs/wismesh-repeater-mini-1w.html){ .md-button .md-button--primary }**
+:material-cart: **[Full Build Guide → WisMesh Repeater Mini 1W](wismesh-repeater-mini-1w.md){ .md-button .md-button--primary }**
 
 ---
 
@@ -301,7 +301,7 @@ Don't want to build anything? These come fully assembled. Mount them, configure 
 
 - **Best value:** SenseCAP Solar P1 Pro. 5W solar panel, 4x 18650 batteries, GPS, ~$90
 - **Easiest deploy:** WisMesh Repeater. IP67 weatherproof, mount and forget
-- **Want the Repeater Mini?** Skip the stock version and build the **1W upgrade** instead. It's [our #1 rooftop pick](/docs/wismesh-repeater-mini-1w.html): same enclosure, 6x the TX power, no soldering.
+- **Want the Repeater Mini?** Skip the stock version and build the **1W upgrade** instead. It's [our #1 rooftop pick](wismesh-repeater-mini-1w.md): same enclosure, 6x the TX power, no soldering.
 - **Premium turnkey:** Atlavox Beacon. Professional mounting hardware, dual SMA connectors, rugged build
 - **Need WiFi/MQTT?** Heltec V4 Solar Node. Heltec V4 board (+28 dBm), 25W solar panel, 6x 18650 battery bay, 5.5 dBi IP67 antenna, mast brackets included
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,7 @@
 site_name: Arizona Meshtastic Community
 theme:
   name: material
+  custom_dir: overrides
   language: en
   logo: assets/images/logo.png
   favicon: assets/images/favicon.png
@@ -76,10 +77,11 @@ extra_javascript:
   - assets/js/nodeData.js # Node Info
   - assets/js/a11y.js # Skip-link focus management
 
+# The Accessibility / Privacy footer links are rendered by
+# overrides/partials/copyright.html using {{ base_url }}, so they resolve under
+# any base path. Hardcoding "/accessibility.html" here 404s on a sub-path build.
 copyright: >
   Copyright &copy; 2026 Arizona Meshtastic Community
-  &nbsp;&middot;&nbsp; <a href="/accessibility.html">Accessibility</a>
-  &nbsp;&middot;&nbsp; <a href="/privacy.html">Privacy Policy</a>
 extra:
   social:
     - icon: fontawesome/brands/discord

--- a/overrides/partials/copyright.html
+++ b/overrides/partials/copyright.html
@@ -1,0 +1,25 @@
+{#-
+  Override of Material's copyright partial (mirrors its markup; re-check on a
+  major theme upgrade).
+
+  The only change is the Accessibility / Privacy footer links: they are built
+  from {{ base_url }} so they resolve at every page depth AND under any base
+  path -- the production root (azmsh.net) and any project-pages build served
+  from a sub-path. Absolute "/accessibility.html" links resolve on azmsh.net
+  but 404 under a sub-path, so they are intentionally not used here.
+-#}
+<div class="md-copyright">
+  {% if config.copyright %}
+    <div class="md-copyright__highlight">
+      {{ config.copyright }}
+      &nbsp;&middot;&nbsp; <a href="{{ base_url }}/accessibility.html">Accessibility</a>
+      &nbsp;&middot;&nbsp; <a href="{{ base_url }}/privacy.html">Privacy Policy</a>
+    </div>
+  {% endif %}
+  {% if not config.extra.generator == false %}
+    Made with
+    <a href="https://squidfunk.github.io/mkdocs-material/" target="_blank" rel="noopener">
+      Material for MkDocs
+    </a>
+  {% endif %}
+</div>


### PR DESCRIPTION
The Accessibility and Privacy links added in #25 are hardcoded as
`/accessibility.html` and `/privacy.html`. Those resolve on azmsh.net but 404 on
any build served from a sub-path, which is every PR preview — so the two pages
that exist specifically for accessibility compliance are the two you can't reach
when reviewing a change.

Moved out of the `copyright:` string into an override of Material's copyright
partial, which builds them from `{{ base_url }}`. Also relativized the four
`/docs/wismesh-repeater-mini-1w.html` links in Recommended Hardware, which have
the same problem.

**What to look at:** the footer of any page on the preview, then the same page on
the [before build](https://rancur.github.io/azmsh-site/preview/main/) — the links
404 there.

**Not in this PR:** links whose target pages move in PRs 6 and 7.

**Preview:** https://rancur.github.io/azmsh-site/preview/split-01-footer-links/
