### PR TITLE
docs: stop hardcoding the default PSK and preset names

### DIFF
--- a/docs/docs/suggested_channels.md
+++ b/docs/docs/suggested_channels.md
@@ -27,7 +27,7 @@ Pick your platform below. The flow is the same idea everywhere: open the Meshtas
 find the **Channels** editor, add a channel, and enter the **Name** and **Key** from the
 [table further down](#the-channels) exactly as written.
 
-???+ note "Android"
+??? note "Android"
 
     1. Open the **Meshtastic** app and make sure your node is connected over Bluetooth.
     2. Tap the **Settings** tab, then open **Channels**.
@@ -39,7 +39,7 @@ find the **Channels** editor, add a channel, and enter the **Name** and **Key** 
     6. Leave **Uplink/Downlink** at their defaults unless you have a reason to change them.
     7. Tap **Save** / the send button to write the channel to your node.
 
-    > To use **MediumFast** as your primary channel, you can leave the primary channel's
+    > To use the default preset as your primary channel, you can leave the primary channel's
     > name **blank**. An empty primary name is the `default` channel.
 
 ??? note "iOS / iPadOS / macOS"
@@ -54,7 +54,7 @@ find the **Channels** editor, add a channel, and enter the **Name** and **Key** 
     6. Enter the **Key** (PSK) from the table exactly as written.
     7. Tap **Save**, then make sure you **send the configuration** back to your node.
 
-    > To use **MediumFast** as your primary channel, you can leave the primary channel's
+    > To use the default preset as your primary channel, you can leave the primary channel's
     > name **blank**. An empty primary name is the `default` channel.
 
 ??? note "Other (Web Client / Apple Watch / CLI)"
@@ -93,7 +93,6 @@ see every column.
 
 | Channel Name (case sensitive) | Key | Size (iOS only) | Description |
 |:------------------------------|:----|:----------------|:------------|
-| `MediumFast` | `AQ==` | Default | The default primary MediumFast channel. Name can also be left blank. |
 | `azmsh` | `AQ==` | Default | The Arizona channel, great for running tests and general chatter. |
 | `Weather` | `Ww==` | 1-byte | Users post from their weather stations on their roofs, great for checking the weather every hour and making sure your node is consistently receiving. |
 | `Traffic` | `TQ==` | 1-byte | Local traffic reports along with waypoints showing where there is traffic on the map. |

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -83,7 +83,7 @@ A typical packet travels like this:
 2. A node on the mesh that is connected to MQTT relays that packet to an MQTT
    broker.
 3. Our ingestion tool reads the packet from the broker and decodes it using the
-   public default key (AQ==).
+   well-known public default key that ships with every Meshtastic device.
 4. The decoded data is shown in our tools, such as view.azmsh.net.
 
 Our broker is set up for uploads only. Nodes can send data to it, but downlink is
@@ -95,9 +95,9 @@ changes how your node behaves.**
 ## Important: public-channel data is not private
 
 Meshtastic's standard channels are secured only with a default encryption key
-(AQ==) that ships with every device and is publicly known. This is not unique to
-one channel. The same default key is used by the common presets, such as LongFast
-and MediumFast, whenever a channel is left on the default key. Because that key is
+that ships with every device and is publicly known. This is not unique to
+one channel. The same default key is used by the common modem presets whenever a
+channel is left on the default key. Because that key is
 public, anyone running Meshtastic can read traffic that uses it. It is not
 private, even though it is technically "encrypted."
 


### PR DESCRIPTION
The privacy page quotes the default key literally as `AQ==` and names
LongFast/MediumFast, and Suggested Channels lists `MediumFast` as a row in the
community channel table — which reads as an invitation to add your own primary
channel a second time as a secondary. Replaced with the general description in
both places, dropped the row, and collapsed the Android accordion so both
platform sections start the same way.

**What to look at:** Suggested Channels → the table and the two platform
accordions; Privacy Policy → "public-channel data is not private".

**Not in this PR:** the "your primary is separate" callout, which needs the Start
Here page. It ships in PR 6.

**Preview:** https://rancur.github.io/azmsh-site/preview/split-02-dehardcode-presets/
